### PR TITLE
Fix bugrisk on openapi body decorator

### DIFF
--- a/sanic_ext/extensions/openapi/openapi.py
+++ b/sanic_ext/extensions/openapi/openapi.py
@@ -168,6 +168,8 @@ def body(
                 retval = await retval
             return retval
 
+        if func in OperationStore():
+            OperationStore()[handler] = OperationStore().pop(func)
         OperationStore()[handler].body(body_content, **params)
         return handler
 


### PR DESCRIPTION
There is a problem that the sub-content disappears when using the body decorator due to the validation handler.
I solved it by simply getting information on existing functions.