### PR TITLE
Change CDN for Swagger UI

### DIFF
--- a/sanic_ext/__init__.py
+++ b/sanic_ext/__init__.py
@@ -5,7 +5,7 @@ from sanic_ext.extensions.openapi import openapi
 from sanic_ext.extras.serializer.decorator import serializer
 from sanic_ext.extras.validation.decorator import validate
 
-__version__ = "21.9.0"
+__version__ = "21.9.1"
 __all__ = [
     "Config",
     "Extend",

--- a/sanic_ext/config.py
+++ b/sanic_ext/config.py
@@ -33,6 +33,7 @@ class Config(SanicConfig):
         oas_ui_default: Optional[str] = "redoc",
         oas_ui_redoc: bool = True,
         oas_ui_swagger: bool = True,
+        oas_ui_swagger_version: str = "4.1.0",
         oas_uri_to_config: str = "/swagger-config",
         oas_uri_to_json: str = "/openapi.json",
         oas_uri_to_redoc: str = "/redoc",
@@ -66,6 +67,7 @@ class Config(SanicConfig):
         self.OAS_UI_DEFAULT = oas_ui_default
         self.OAS_UI_REDOC = oas_ui_redoc
         self.OAS_UI_SWAGGER = oas_ui_swagger
+        self.OAS_UI_SWAGGER_VERSION = oas_ui_swagger_version
         self.OAS_URI_TO_CONFIG = oas_uri_to_config
         self.OAS_URI_TO_JSON = oas_uri_to_json
         self.OAS_URI_TO_REDOC = oas_uri_to_redoc

--- a/sanic_ext/extensions/openapi/blueprint.py
+++ b/sanic_ext/extensions/openapi/blueprint.py
@@ -5,7 +5,6 @@ from os.path import abspath, dirname, realpath
 from sanic.blueprints import Blueprint
 from sanic.config import Config
 from sanic.response import html, json
-
 from sanic_ext.extensions.openapi.builders import (
     OperationStore,
     SpecificationBuilder,
@@ -28,13 +27,14 @@ def blueprint_factory(config: Config):
         if getattr(config, f"OAS_UI_{ui}".upper()):
             path = getattr(config, f"OAS_PATH_TO_{ui}_HTML".upper())
             uri = getattr(config, f"OAS_URI_TO_{ui}".upper())
+            version = getattr(config, f"OAS_UI_{ui}_VERSION".upper(), "")
             html_path = path if path else f"{dir_path}/{ui}.html"
 
             with open(html_path, "r") as f:
                 page = f.read()
 
             def index(request, page):
-                return html(page)
+                return html(page.replace("__VERSION__", version))
 
             bp.add_route(partial(index, page=page), uri, name=ui)
             if config.OAS_UI_DEFAULT and config.OAS_UI_DEFAULT == ui:

--- a/sanic_ext/extensions/openapi/blueprint.py
+++ b/sanic_ext/extensions/openapi/blueprint.py
@@ -5,6 +5,7 @@ from os.path import abspath, dirname, realpath
 from sanic.blueprints import Blueprint
 from sanic.config import Config
 from sanic.response import html, json
+
 from sanic_ext.extensions.openapi.builders import (
     OperationStore,
     SpecificationBuilder,

--- a/sanic_ext/extensions/openapi/ui/swagger.html
+++ b/sanic_ext/extensions/openapi/ui/swagger.html
@@ -16,9 +16,9 @@
 
     <body>
         <div id="openapi">
-            <script src="//cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui-bundle.js"></script>
+            <script src="//cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui-bundle.min.js"></script>
             <script
-                src="//cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui-standalone-preset.js"></script>
+                src="//cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui-standalone-preset.min.js"></script>
             <script>
                 window.onload = function () {
                     const ui = SwaggerUIBundle({

--- a/sanic_ext/extensions/openapi/ui/swagger.html
+++ b/sanic_ext/extensions/openapi/ui/swagger.html
@@ -4,7 +4,8 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" type="text/css" href="//pagecdn.io/lib/swagger-ui/latest/swagger-ui.css">
+        <link rel="stylesheet" type="text/css"
+            href="//cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui.min.css">
         <title>OpenAPI Swagger</title>
         <style>
             body {
@@ -15,8 +16,9 @@
 
     <body>
         <div id="openapi">
-            <script src="//pagecdn.io/lib/swagger-ui/latest/swagger-ui-bundle.js"></script>
-            <script src="//pagecdn.io/lib/swagger-ui/latest/swagger-ui-standalone-preset.js"></script>
+            <script src="//cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui-bundle.js"></script>
+            <script
+                src="//cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui-standalone-preset.js"></script>
             <script>
                 window.onload = function () {
                     const ui = SwaggerUIBundle({


### PR DESCRIPTION
Closes #6 

It seems that the CDN we were using no longer hosts the Swagger UI assets. Furthermore, the Cloudflare CDN is version only (no `latest`). Therefore, this PR does two things:

1. Changes the CDN to CF
2. Introduces a config value to change the swagger version