### PR TITLE
Fix bug with alowed methods on a dynamic route

### DIFF
--- a/sanic_ext/__init__.py
+++ b/sanic_ext/__init__.py
@@ -5,7 +5,7 @@ from sanic_ext.extensions.openapi import openapi
 from sanic_ext.extras.serializer.decorator import serializer
 from sanic_ext.extras.validation.decorator import validate
 
-__version__ = "21.9.2"
+__version__ = "21.9.3"
 __all__ = [
     "Config",
     "Extend",

--- a/sanic_ext/extensions/http/cors.py
+++ b/sanic_ext/extensions/http/cors.py
@@ -280,9 +280,7 @@ def _add_methods_header(request: Request, response: HTTPResponse) -> None:
                 methods = group_methods
 
     if methods:
-        response.headers[ALLOW_METHODS_HEADER] = ",".join(
-            list(map(lambda x: x.upper(), methods))
-        )
+        response.headers[ALLOW_METHODS_HEADER] = ",".join(methods).upper()
 
 
 def _add_vary_header(request: Request, response: HTTPResponse) -> None:

--- a/sanic_ext/extensions/http/cors.py
+++ b/sanic_ext/extensions/http/cors.py
@@ -271,7 +271,7 @@ def _add_methods_header(request: Request, response: HTTPResponse) -> None:
     if not with_credentials and "*" in allow_methods:
         methods = {"*"}
     elif request.route:
-        group = request.app.router.groups.get(request.route.parts)
+        group = request.app.router.groups.get(request.route.segments)
         if group:
             group_methods = {method.lower() for method in group.methods}
             if allow_methods:
@@ -280,7 +280,9 @@ def _add_methods_header(request: Request, response: HTTPResponse) -> None:
                 methods = group_methods
 
     if methods:
-        response.headers[ALLOW_METHODS_HEADER] = ",".join(methods)
+        response.headers[ALLOW_METHODS_HEADER] = ",".join(
+            list(map(lambda x: x.upper(), methods))
+        )
 
 
 def _add_vary_header(request: Request, response: HTTPResponse) -> None:


### PR DESCRIPTION
When adding the allowed methods header, routes were being looked up using `route.parts`. This is the actual raw values rather than `route.segments` which allows for dynamic placeholders. Therefore, when trying to add headers to a dynamic route, the methods were not retrievable.