### PR TITLE
Allow Optional to be used on an annotation and properly translate to OAS

### DIFF
--- a/sanic_ext/extensions/openapi/types.py
+++ b/sanic_ext/extensions/openapi/types.py
@@ -65,6 +65,15 @@ class Schema(Definition):
 
     @staticmethod
     def make(value, **kwargs):
+        _type = type(value)
+        if (
+            issubclass(_type, t._GenericAlias)
+            and len(value.__args__) == 2
+            and type(None) in value.__args__
+        ):
+            value = value.__args__[0]
+            kwargs["nullable"] = True
+
         if isinstance(value, Schema):
             return value
         if value == bool:
@@ -85,8 +94,6 @@ class Schema(Definition):
             return Time(**kwargs)
         elif value == datetime:
             return DateTime(**kwargs)
-
-        _type = type(value)
 
         if _type == bool:
             return Boolean(default=value, **kwargs)

--- a/sanic_ext/extensions/openapi/types.py
+++ b/sanic_ext/extensions/openapi/types.py
@@ -83,7 +83,9 @@ class Schema(Definition):
             and len(args) == 2
             and type(None) in args
         ):
-            value = args[0]
+            value = next(
+                filter(lambda x: x is not type(None), args)  # noqa: E721
+            )
             kwargs["nullable"] = True
 
         if isinstance(value, Schema):


### PR DESCRIPTION
Fixes #12 

This allows `Optional` to be properly parsed.

```python
class Foo(TypedDict):
    bar: Optional[bool]


class FooBar(TypedDict):
    foo: Optional[Foo]
    bar: Optional[str]

...

@openapi.response(200, {"application/json": FooBar})
```

![image](https://user-images.githubusercontent.com/166269/144421697-b1d6fbf2-2e33-4dbd-a03e-5df3908252d9.png)
![image](https://user-images.githubusercontent.com/166269/144421724-f2a4b967-c351-4d24-b81c-259936032358.png)
