### PR TITLE
Add cascading dependency injection

### DIFF
--- a/sanic_ext/bootstrap.py
+++ b/sanic_ext/bootstrap.py
@@ -13,6 +13,7 @@ from sanic_ext.extensions.http.extension import HTTPExtension
 from sanic_ext.extensions.injection.extension import InjectionExtension
 from sanic_ext.extensions.injection.registry import InjectionRegistry
 from sanic_ext.extensions.openapi.extension import OpenAPIExtension
+from sanic_ext.utils.string import camel_to_snake
 
 MIN_SUPPORT = (21, 3, 2)
 
@@ -83,3 +84,13 @@ class Extend:
         if not self._injection_registry:
             raise SanicException("Injection extension not enabled")
         self._injection_registry.register(type, constructor)
+
+    def add_to_ctx(self, obj: Any, name: Optional[str] = None) -> None:
+        if not name:
+            name = camel_to_snake(obj.__class__.__name__)
+        setattr(self.app.ctx, name, obj)
+
+        def getter(*_):
+            return obj
+
+        self.injection(obj.__class__, getter)

--- a/sanic_ext/extensions/injection/constructor.py
+++ b/sanic_ext/extensions/injection/constructor.py
@@ -48,9 +48,8 @@ class Constructor:
             return retval
         except TypeError as e:
             raise ServerError(
-                "Failure to inject dependencies. Perhaps one of your "
-                "injection initializations is out of order. Make sure that "
-                f"all dependencies for '{self.func.__name__}' have been "
+                "Failure to inject dependencies. Make sure that all "
+                f"dependencies for '{self.func.__name__}' have been "
                 "registered before it."
             ) from e
 

--- a/sanic_ext/extensions/injection/constructor.py
+++ b/sanic_ext/extensions/injection/constructor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from inspect import isawaitable
-from re import L
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -39,9 +38,6 @@ class Constructor:
         return f"<{self.__class__.__name__}(func={self.func.__name__})>"
 
     async def __call__(self, request, **kwargs):
-        # TODO
-        # - need to check if self.func requires kwargs and only pass
-        # them if required.  This should capture route params, etc.
         try:
             args = await gather_args(self.injections, request, **kwargs)
             if self.pass_kwargs:

--- a/sanic_ext/extensions/injection/constructor.py
+++ b/sanic_ext/extensions/injection/constructor.py
@@ -50,11 +50,13 @@ class Constructor:
             raise ServerError(
                 "Failure to inject dependencies. Make sure that all "
                 f"dependencies for '{self.func.__name__}' have been "
-                "registered before it."
+                "registered."
             ) from e
 
     def prepare(
-        self, injection_registry: InjectionRegistry, allowed_types: Set[Any]
+        self,
+        injection_registry: InjectionRegistry,
+        allowed_types: Set[Type[object]],
     ) -> None:
         hints = get_type_hints(self.func)
         missing = []
@@ -87,7 +89,7 @@ class Constructor:
 
     def check_circular(
         self,
-        checked: Set[Any],
+        checked: Set[Type[object]],
     ) -> None:
         dependencies = set(self.injections.values())
         for dependency, constructor in dependencies:

--- a/sanic_ext/extensions/injection/constructor.py
+++ b/sanic_ext/extensions/injection/constructor.py
@@ -114,6 +114,7 @@ async def gather_args(injections, request, **kwargs) -> Dict[str, Any]:
 async def do_cast(_type, constructor, request, **kwargs):
     cast = constructor if constructor else _type
     args = [request] if constructor else []
+
     retval = cast(*args, **kwargs)
     if isawaitable(retval):
         retval = await retval

--- a/sanic_ext/extensions/injection/constructor.py
+++ b/sanic_ext/extensions/injection/constructor.py
@@ -14,6 +14,7 @@ from typing import (
 
 from sanic import Request
 from sanic.exceptions import ServerError
+
 from sanic_ext.exceptions import InitError
 
 if TYPE_CHECKING:

--- a/sanic_ext/extensions/injection/constructor.py
+++ b/sanic_ext/extensions/injection/constructor.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from inspect import isawaitable
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Set,
+    Tuple,
+    Type,
+    get_type_hints,
+)
+
+from sanic import Request
+from sanic.exceptions import ServerError
+from sanic_ext.exceptions import InitError
+
+if TYPE_CHECKING:
+    from .registry import InjectionRegistry
+
+
+class Constructor:
+    EXEMPT_ANNOTATIONS = (Request,)
+
+    def __init__(
+        self,
+        func: Callable[..., Any],
+    ):
+        self.func = func
+        self.injections: Dict[str, Tuple[Type, Constructor]] = {}
+
+    def __str__(self) -> str:
+        return f"<{self.__class__.__name__}:{self.func.__name__}>"
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}(func={self.func.__name__})>"
+
+    async def __call__(self, request, **kwargs):
+        try:
+            args = await gather_args(self.injections, request, **kwargs)
+            return self.func(request, **args)
+        except TypeError as e:
+            raise ServerError(
+                "Failure to inject dependencies. Perhaps one of your "
+                "injection initializations is out of order. Make sure that "
+                f"all dependencies for '{self.func.__name__}' have been "
+                "registered before it."
+            ) from e
+
+    def prepare(self, injection_registry: InjectionRegistry) -> None:
+        hints = get_type_hints(self.func)
+        missing = []
+        for param, annotation in hints.items():
+            if annotation not in self.EXEMPT_ANNOTATIONS:
+                dependency = injection_registry.get(annotation)
+                if not dependency:
+                    missing.append((param, annotation))
+                self.injections[param] = (annotation, dependency)
+
+        if missing:
+            dependencies = "\n".join(
+                [f"  - {param}: {annotation}" for param, annotation in missing]
+            )
+            raise InitError(
+                "Unable to resolve dependencies for "
+                f"'{self.func.__name__}'. Could not find the following "
+                f"dependencies:\n{dependencies}.\nMake sure the dependencies "
+                "are declared using ext.injection. See "
+                "https://sanicframework.org/en/plugins/sanic-ext/injection."
+                "html#injecting-services for more details."
+            )
+
+        self.check_circular(set())
+
+    def check_circular(
+        self,
+        checked: Set[Any],
+    ) -> None:
+        dependencies = set(self.injections.values())
+        for dependency, constructor in dependencies:
+            if dependency in checked:
+                raise InitError(
+                    "Circular dependency injection detected on "
+                    f"'{self.func.__name__}'. Check dependencies of "
+                    f"'{constructor.func.__name__}' which may contain "
+                    f"circular dependency chain with {dependency}."
+                )
+            checked.add(dependency)
+            constructor.check_circular(checked)
+
+
+async def gather_args(injections, request, **kwargs) -> Dict[str, Any]:
+    return {
+        name: await do_cast(_type, constructor, request, **kwargs)
+        for name, (_type, constructor) in injections.items()
+    }
+
+
+async def do_cast(_type, constructor, request, **kwargs):
+    cast = constructor if constructor else _type
+    args = [request] if constructor else []
+    retval = cast(*args, **kwargs)
+    if isawaitable(retval):
+        retval = await retval
+    return retval

--- a/sanic_ext/extensions/injection/injector.py
+++ b/sanic_ext/extensions/injection/injector.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, Optional, Tuple, Type, get_type_hints
 
 from sanic import Sanic
 from sanic.constants import HTTP_METHODS
+
 from sanic_ext.extensions.injection.constructor import gather_args
 
 from .registry import InjectionRegistry, SignatureRegistry

--- a/sanic_ext/extensions/injection/injector.py
+++ b/sanic_ext/extensions/injection/injector.py
@@ -13,7 +13,7 @@ from .registry import InjectionRegistry, SignatureRegistry
 def add_injection(app: Sanic, injection_registry: InjectionRegistry) -> None:
     signature_registry = _setup_signature_registry(app, injection_registry)
 
-    @app.before_server_start
+    @app.after_server_start
     async def finalize_injections(app: Sanic, _):
         router_converters = set(
             allowed[0] for allowed in app.router.regex_types.values()

--- a/sanic_ext/extensions/injection/injector.py
+++ b/sanic_ext/extensions/injection/injector.py
@@ -80,7 +80,7 @@ def _setup_signature_registry(
                         injection_registry[annotation],
                     )
                     for param, annotation in hints.items()
-                    if annotation in injection_registry._registry
+                    if annotation in injection_registry
                 }
                 registry.register(name, injections)
 

--- a/sanic_ext/extensions/injection/injector.py
+++ b/sanic_ext/extensions/injection/injector.py
@@ -1,8 +1,11 @@
-from inspect import Signature, getmembers, isawaitable, isfunction, signature
-from typing import Any, Callable, Dict, Optional, Tuple, Type
+from __future__ import annotations
+
+from inspect import getmembers, isfunction
+from typing import Any, Callable, Dict, Optional, Tuple, Type, get_type_hints
 
 from sanic import Sanic
 from sanic.constants import HTTP_METHODS
+from sanic_ext.extensions.injection.constructor import gather_args
 
 from .registry import InjectionRegistry, SignatureRegistry
 
@@ -10,30 +13,22 @@ from .registry import InjectionRegistry, SignatureRegistry
 def add_injection(app: Sanic, injection_registry: InjectionRegistry) -> None:
     signature_registry = _setup_signature_registry(app, injection_registry)
 
+    @app.before_server_start
+    async def finalize_injections(*_):
+        injection_registry.finalize()
+
     @app.signal("http.routing.after")
     async def inject_kwargs(request, route, kwargs, **_):
         nonlocal signature_registry
 
         for name in (route.name, f"{route.name}_{request.method.lower()}"):
-            injections = signature_registry[name]
+            injections = signature_registry.get(name)
             if injections:
                 break
 
         if injections:
-            injected_args = {
-                name: await _do_cast(_type, constructor, request, **kwargs)
-                for name, (_type, constructor) in injections.items()
-            }
+            injected_args = await gather_args(injections, request)
             request.match_info.update(injected_args)
-
-
-async def _do_cast(_type, constructor, request, **kwargs):
-    cast = constructor if constructor else _type
-    args = [request] if constructor else []
-    retval = cast(*args, **kwargs)
-    if isawaitable(retval):
-        retval = await retval
-    return retval
 
 
 def _http_method_predicate(member):
@@ -61,17 +56,20 @@ def _setup_signature_registry(
                     )
                 ]
             for name, handler in handlers:
-                sig = signature(handler)
+                try:
+                    hints = get_type_hints(handler)
+                except TypeError:
+                    continue
+
                 injections: Dict[
                     str, Tuple[Type, Optional[Callable[..., Any]]]
                 ] = {
-                    param.name: (
-                        param.annotation,
-                        injection_registry[param.annotation],
+                    param: (
+                        annotation,
+                        injection_registry[annotation],
                     )
-                    for param in sig.parameters.values()
-                    if param.annotation != Signature.empty
-                    and param.annotation in injection_registry._registry
+                    for param, annotation in hints.items()
+                    if annotation in injection_registry._registry
                 }
                 registry.register(name, injections)
 

--- a/sanic_ext/extensions/injection/registry.py
+++ b/sanic_ext/extensions/injection/registry.py
@@ -1,5 +1,7 @@
 from typing import Any, Callable, Dict, Optional, Tuple, Type
 
+from .constructor import Constructor
+
 
 class InjectionRegistry:
     def __init__(self):
@@ -11,10 +13,20 @@ class InjectionRegistry:
     def __str__(self) -> str:
         return str(self._registry)
 
+    def get(self, key, default=None):
+        return self._registry.get(key, default)
+
     def register(
         self, _type: Type, constructor: Optional[Callable[..., Any]]
     ) -> None:
+        if constructor:
+            constructor = Constructor(constructor)
         self._registry[_type] = constructor
+
+    def finalize(self):
+        for constructor in self._registry.values():
+            if isinstance(constructor, Constructor):
+                constructor.prepare(self)
 
 
 class SignatureRegistry:
@@ -24,10 +36,13 @@ class SignatureRegistry:
         ] = {}
 
     def __getitem__(self, key):
-        return self._registry.get(key)
+        return self._registry[key]
 
     def __str__(self) -> str:
         return str(self._registry)
+
+    def get(self, key, default=None):
+        return self._registry.get(key, default)
 
     def register(
         self,

--- a/sanic_ext/extensions/injection/registry.py
+++ b/sanic_ext/extensions/injection/registry.py
@@ -23,10 +23,10 @@ class InjectionRegistry:
             constructor = Constructor(constructor)
         self._registry[_type] = constructor
 
-    def finalize(self):
+    def finalize(self, allowed_types):
         for constructor in self._registry.values():
             if isinstance(constructor, Constructor):
-                constructor.prepare(self)
+                constructor.prepare(self, allowed_types)
 
 
 class SignatureRegistry:

--- a/sanic_ext/extensions/injection/registry.py
+++ b/sanic_ext/extensions/injection/registry.py
@@ -13,6 +13,9 @@ class InjectionRegistry:
     def __str__(self) -> str:
         return str(self._registry)
 
+    def __contains__(self, other: Any):
+        return other in self._registry
+
     def get(self, key, default=None):
         return self._registry.get(key, default)
 

--- a/sanic_ext/utils/string.py
+++ b/sanic_ext/utils/string.py
@@ -1,0 +1,12 @@
+import re
+
+CAMEL_TO_SNAKE_PATTERNS = (
+    re.compile(r"(.)([A-Z][a-z]+)"),
+    re.compile(r"([a-z0-9])([A-Z])"),
+)
+
+
+def camel_to_snake(name: str) -> str:
+    for pattern in CAMEL_TO_SNAKE_PATTERNS:
+        name = pattern.sub(r"\1_\2", name)
+    return name.lower()

--- a/tests/extensions/injection/test_add_dependency.py
+++ b/tests/extensions/injection/test_add_dependency.py
@@ -5,6 +5,7 @@ import pytest
 from sanic import Request, json, text
 from sanic.exceptions import SanicException
 from sanic.views import HTTPMethodView
+
 from sanic_ext import Extend
 
 

--- a/tests/extensions/injection/test_dependency.py
+++ b/tests/extensions/injection/test_dependency.py
@@ -1,0 +1,31 @@
+from sanic import Request, text
+
+
+class Foo:
+    def bar(self):
+        return "foobar"
+
+
+def test_dependency_added(app):
+    foo = Foo()
+    foobar = Foo()
+
+    app.ctx.ext.dependency(foo)
+    app.ctx.ext.dependency(foobar, name="something")
+
+    assert app.ctx._dependencies.foo is foo
+    assert app.ctx._dependencies.something is foobar
+
+
+def test_dependency_injection(app):
+    foo = Foo()
+
+    app.ctx.ext.dependency(foo)
+
+    @app.get("/getfoo")
+    async def getfoo(request: Request, foo: Foo):
+        return text(foo.bar())
+
+    _, response = app.test_client.get("/getfoo")
+
+    assert response.text == "foobar"

--- a/tests/extensions/injection/test_injection_registry.py
+++ b/tests/extensions/injection/test_injection_registry.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, call
 import pytest
 from sanic import Request
 from sanic.exceptions import ServerError
+
 from sanic_ext.exceptions import InitError
 from sanic_ext.extensions.injection.constructor import Constructor, gather_args
 from sanic_ext.extensions.injection.registry import InjectionRegistry

--- a/tests/extensions/injection/test_injection_registry.py
+++ b/tests/extensions/injection/test_injection_registry.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, call
+
+import pytest
+from sanic import Request
+from sanic.exceptions import ServerError
+from sanic_ext.exceptions import InitError
+from sanic_ext.extensions.injection.constructor import Constructor, gather_args
+from sanic_ext.extensions.injection.registry import InjectionRegistry
+
+
+class Foo:
+    def __init__(self, num: int):
+        self.num = num
+        self.mock = AsyncMock()
+
+    @classmethod
+    async def create(cls, request: Request, bar: int):
+        instance = cls(bar)
+        await instance.mock(request, bar)
+        return instance
+
+
+class Bar:
+    def __init__(self, foo: Foo):
+        self.foo = foo
+
+    @classmethod
+    async def create(cls, request: Request, foo: Foo):
+        return cls(foo)
+
+
+class Chicken:
+    @classmethod
+    def create(cls, egg: Egg):
+        return cls()
+
+
+class Egg:
+    @classmethod
+    def create(cls, chicken: Chicken):
+        return cls()
+
+
+@pytest.mark.asyncio
+async def test_gather_args():
+    func = AsyncMock()
+    func.return_value = 999
+    injections = {"some_foo": (Foo, func)}
+    request = object()
+    kwargs = {"zero": 0, "one": True, "two": "2", "three": None}
+
+    args = await gather_args(injections, request, **kwargs)
+    assert args == {"some_foo": 999}
+    assert func.call_args == call(request, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_circular_refs():
+    injections = InjectionRegistry()
+    injections.register(Chicken, Chicken.create)
+    injections.register(Egg, Egg.create)
+
+    assert isinstance(injections[Chicken], Constructor)
+    assert isinstance(injections[Egg], Constructor)
+
+    message = (
+        "Circular dependency injection detected on 'create'. Check "
+        "dependencies of 'create' which may contain circular dependency "
+        f"chain with {Chicken}."
+    )
+    with pytest.raises(InitError, match=message):
+        injections.finalize([])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raises,allowed", ((False, (int,)), (True, [])))
+async def test_finalize_allowed_types(raises, allowed):
+    injections = InjectionRegistry()
+    injections.register(Foo, Foo.create)
+
+    if raises:
+        with pytest.raises(
+            InitError, match=".Could not find the following dependencies."
+        ):
+            injections.finalize(allowed)
+    else:
+        injections.finalize(allowed)
+
+
+async def test_constructor():
+    injections = InjectionRegistry()
+    injections.register(Foo, Foo.create)
+    injections.finalize({int})
+    request = object()
+    constructor = injections[Foo]
+
+    foo = await constructor(request, bar=999)
+
+    assert isinstance(foo, Foo)
+    assert foo.num == 999
+    assert constructor.pass_kwargs
+    foo.mock.assert_awaited_once_with(request, 999)
+
+
+async def test_constructor_nested():
+    injections = InjectionRegistry()
+    injections.register(Foo, Foo.create)
+    injections.register(Bar, Bar.create)
+    injections.finalize({int})
+    request = object()
+    constructor_bar = injections[Bar]
+
+    bar = await constructor_bar(request, bar=999)
+
+    assert isinstance(bar, Bar)
+    assert isinstance(bar.foo, Foo)
+    assert bar.foo.num == 999
+    assert not constructor_bar.pass_kwargs
+    bar.foo.mock.assert_awaited_once_with(request, 999)
+
+
+async def test_constructor_failure_kwargs():
+    injections = InjectionRegistry()
+    injections.register(Foo, Foo.create)
+    injections.finalize({int})
+    request = object()
+    constructor = injections[Foo]
+
+    message = (
+        "Failure to inject dependencies. Make sure that all dependencies "
+        "for 'create' have been registered."
+    )
+    with pytest.raises(ServerError, match=message):
+        await constructor(request)
+
+
+async def test_constructor_failure_nested():
+    injections = InjectionRegistry()
+    injections.register(Foo, Foo.create)
+    injections.register(Bar, Bar.create)
+    injections.finalize({int})
+    request = object()
+    constructor: Bar = injections[Bar]
+
+    message = (
+        "Failure to inject dependencies. Make sure that all dependencies "
+        "for 'create' have been registered."
+    )
+    with pytest.raises(ServerError, match=message):
+        await constructor(request)

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 ; envlist = {py37,py38,py39}-sanic{21.6}, check
-envlist = {py37,py38,py39}, check
+envlist = {py38,py39}, check
 
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39, check
 


### PR DESCRIPTION
## Nested dependencies

This PR allows for the constructors of dependencies to declare nested dependencies.

```python
class A:
    ...

class B:
    def __init__(self, a: A):
        self.a = a

class C:
    def __init__(self, b: B):
        self.b = b

def get_a(request: Request):
    return A()

def get_b(request: Request, a: A):
    return B(a)

def get_c(request: Request, b: B):
    return C(b)

ext.add_dependency(A, get_a)
ext.add_dependency(B, get_b)
ext.add_dependency(C, get_c)
```

## Convenience

This also adds a convenience method that:

1. Adds an item to the application `ctx`
2. creates the constructor
3. adds the injection

```python
class Foo:
    def bar(self):
        return "foobar"


@app.before_server_start
async def setup_foo(app, _):
    ext.dependency(Foo())


@app.get("/getfoo")
async def getfoo(request: Request, foo: Foo):
    return text(foo.bar())
```

## Rename

To follow the Sanic API pattern where `add_foo` is a lower level function of `foo`, this PR makes the following change:

1. `Extend.injection` is renamed to `Extend.add_dependency`
2. `Extend.dependency` is the new convenience method
3. `Extend.injection` is added as a deprecated alias to `Extend.add_dependency`

---

TODO:
- [x] Tests
- [x] A custom router type (`app.router.register_pattern`) should have a return type so that we can determine that it is not a missing dependency. If it does not, then we need to either: raise an exception at startup because there is a potential missing dependency (current implementation), or raise a warning and defer the exception until a request is made
    _I think I am leaving this as is for now. It seems a small edge case which we can defer to a later point if it is a problem_