### PR TITLE
Unpin Linters Version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     "pyyaml>=3.0.0",
 ]
 
-dev_requires = ["black==19.3b0", "flake8==3.7.7", "isort==4.3.19"]
+dev_requires = ["black>=21.4b2", "flake8>=3.7.7", "isort>=5.0.0"]
 
 test_requires = [
     "sanic_testing==0.7.0",


### PR DESCRIPTION
Unpin the linters' version to let them work with `make pretty` in the repo.

In my testing, with the current pinned version of the linters, errors below may occur:

### isort
Command: `isort --line-length 79 --trailing-comma -m 3 sanic_ext tests`
```
isort --line-length 79 --trailing-comma -m 3 sanic_ext tests
usage: isort [-h] [-a ADD_IMPORTS] [-ac] [-af] [-b KNOWN_STANDARD_LIBRARY] [-c] [-ca] [-cs] [-d] [-df] [-ds] [-dt] [-e] [-f KNOWN_FUTURE_LIBRARY] [-fas] [-fass] [-ff FROM_FIRST] [-fgw [FORCE_GRID_WRAP]] [-fss] [-i INDENT]
             [-j JOBS] [-k] [-l LINE_LENGTH] [-lai LINES_AFTER_IMPORTS] [-lbt LINES_BETWEEN_TYPES] [-le LINE_ENDING] [-ls] [-m {0,1,2,3,4,5,6,7}] [-nis] [-nlb NO_LINES_BEFORE] [-ns NOT_SKIP] [-o KNOWN_THIRD_PARTY] [-ot]
             [-p KNOWN_FIRST_PARTY] [-q] [-r] [-rm REMOVE_IMPORTS] [-rr] [-rc] [-s SKIP] [-sd DEFAULT_SECTION] [-sg SKIP_GLOB] [-sl] [-sp SETTINGS_PATH] [-t FORCE_TO_TOP] [-tc] [-up] [-v] [-vb] [--virtual-env VIRTUAL_ENV]
             [--conda-env CONDA_ENV] [-vn] [-w LINE_LENGTH] [-wl WRAP_LENGTH] [-ws] [-y] [--unsafe] [--case-sensitive] [--filter-files]
             [files ...]
isort: error: unrecognized arguments: --line-length sanic_ext tests
make: *** [Makefile:3: pretty] Error 2
```

### black
Command: `black --line-length 79 --target-version=py39 sanic_ext tests`
```
black --line-length 79 --target-version=py39 sanic_ext tests
Usage: black [OPTIONS] [SRC]...
Try 'black -h' for help.

Error: Invalid value for '-t' / '--target-version': 'py39' is not one of 'py27', 'py33', 'py34', 'py35', 'py36', 'py37', 'py38'.
make: *** [Makefile:2: pretty] Error 2
```
 