### PR TITLE
Pass `parameter.fields` When `parameter` is being Passed in

### DIFF
--- a/sanic_ext/extensions/openapi/openapi.py
+++ b/sanic_ext/extensions/openapi/openapi.py
@@ -178,24 +178,27 @@ def body(
 
 def parameter(
     name: Optional[str] = None,
-    schema: Type = str,
-    location: str = "query",
+    schema: Optional[Type] = None,
+    location: Optional[str] = None,
     parameter: Optional[Parameter] = None,
     **kwargs,
 ):
     if parameter:
-        if name:
+        if name or schema or location:
             raise SanicException(
                 "When using a parameter object, you cannot pass "
                 "other arguments."
             )
-
-        name = parameter.fields["name"]
-        schema = parameter.fields["schema"]
-        location = parameter.fields["in"]
+    if not schema:
+        schema = str
+    if not location:
+        location = "query"
 
     def inner(func):
-        OperationStore()[func].parameter(name, schema, location, **kwargs)
+        if parameter:
+            OperationStore()[func].parameter(**parameter.fields)
+        else:
+            OperationStore()[func].parameter(name, schema, location, **kwargs)
         return func
 
     return inner

--- a/sanic_ext/extensions/openapi/openapi.py
+++ b/sanic_ext/extensions/openapi/openapi.py
@@ -189,7 +189,7 @@ def body(
 
 @overload
 def parameter(
-    parameter: Optional[Parameter] = None,
+    parameter: Parameter,
     **kwargs,
 ) -> Callable:
     ...
@@ -197,19 +197,19 @@ def parameter(
 
 @overload
 def parameter(
-    name: Optional[str] = None,
-    schema: Optional[Type] = None,
-    location: Optional[str] = None,
+    name: Optional[str],
+    schema: Optional[Type],
+    location: Optional[str],
     **kwargs,
 ) -> Callable:
     ...
 
 
 def parameter(
-    name: Optional[str] = None,
-    schema: Optional[Type] = None,
-    location: Optional[str] = None,
-    parameter: Optional[Parameter] = None,
+    name=None,
+    schema=None,
+    location=None,
+    parameter=None,
     **kwargs,
 ):
     if parameter:

--- a/sanic_ext/extensions/openapi/openapi.py
+++ b/sanic_ext/extensions/openapi/openapi.py
@@ -196,7 +196,12 @@ def parameter(
 
     def inner(func):
         if parameter:
-            OperationStore()[func].parameter(**parameter.fields)
+            # Temporary solution convert in to location,
+            # need to be changed later.
+            fields = dict(parameter.fields)
+            if "in" in fields:
+                fields["location"] = fields.pop("in")
+            OperationStore()[func].parameter(**fields)
         else:
             OperationStore()[func].parameter(name, schema, location, **kwargs)
         return func

--- a/sanic_ext/extensions/openapi/openapi.py
+++ b/sanic_ext/extensions/openapi/openapi.py
@@ -5,7 +5,18 @@ documentation to OperationStore() and components created in the blueprints.
 """
 from functools import wraps
 from inspect import isawaitable, isclass
-from typing import Any, Dict, List, Optional, Sequence, Type, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from sanic import Blueprint
 from sanic.exceptions import InvalidUsage, SanicException
@@ -176,6 +187,24 @@ def body(
     return inner
 
 
+@overload
+def parameter(
+    parameter: Optional[Parameter] = None,
+    **kwargs,
+) -> Callable:
+    ...
+
+
+@overload
+def parameter(
+    name: Optional[str] = None,
+    schema: Optional[Type] = None,
+    location: Optional[str] = None,
+    **kwargs,
+) -> Callable:
+    ...
+
+
 def parameter(
     name: Optional[str] = None,
     schema: Optional[Type] = None,
@@ -194,7 +223,7 @@ def parameter(
     if not location:
         location = "query"
 
-    def inner(func):
+    def inner(func: Callable):
         if parameter:
             # Temporary solution convert in to location,
             # need to be changed later.

--- a/tests/extensions/openapi/test_parameter.py
+++ b/tests/extensions/openapi/test_parameter.py
@@ -1,0 +1,63 @@
+from sanic import Request, Sanic, text
+
+from sanic_ext import Extend
+from sanic_ext.extensions.openapi import openapi
+from sanic_ext.extensions.openapi.definitions import Parameter
+
+
+def test_parameter_docstring(app: Sanic):
+    DESCRIPTION = "val1 path param"
+
+    @app.route("/test1/<val1>")
+    async def handler1(request: Request, val1: int):
+        """
+        openapi:
+        ---
+        operationId: get.test1
+        parameters:
+        - name: val1
+            in: path
+            description: val1 path param
+            required: true
+            schema:
+            type: integer
+            format: int32
+        """
+        return text("ok")
+
+    @app.route("/test2/<val1>")
+    @openapi.parameter(
+        parameter=Parameter(
+            name="val1", schema=int, location="path", description=DESCRIPTION
+        )
+    )
+    async def handler2(request: Request, val1: int):
+        return text("ok")
+
+    @app.route("/test3/<val1>")
+    @openapi.parameter(
+        "val1", description=DESCRIPTION, required=True, schema=int
+    )
+    async def handler3(request: Request, val1: int):
+        return text("ok")
+
+    test_client = app.test_client
+    _, response = test_client.get("/docs/openapi.json")
+    paths = response.json.get("paths")
+    print(paths)
+    assert paths
+
+    # Brocken test, only happen with the test client, need to be fixed.
+    # assert (
+    #     paths["/test1/{val1}"]["get"]["parameters"][0]["description"]
+    #     == DESCRIPTION
+    # )
+
+    assert (
+        paths["/test2/{val1}"]["get"]["parameters"][0]["description"]
+        == DESCRIPTION
+    )
+    assert (
+        paths["/test3/{val1}"]["get"]["parameters"][0]["description"]
+        == DESCRIPTION
+    )

--- a/tests/extensions/openapi/test_parameter.py
+++ b/tests/extensions/openapi/test_parameter.py
@@ -15,13 +15,13 @@ def test_parameter_docstring(app: Sanic):
         ---
         operationId: get.test1
         parameters:
-        - name: val1
+          - name: val1
             in: path
             description: val1 path param
             required: true
             schema:
-            type: integer
-            format: int32
+                type: integer
+                format: int32
         """
         return text("ok")
 
@@ -48,10 +48,10 @@ def test_parameter_docstring(app: Sanic):
     assert paths
 
     # Brocken test, only happen with the test client, need to be fixed.
-    # assert (
-    #     paths["/test1/{val1}"]["get"]["parameters"][0]["description"]
-    #     == DESCRIPTION
-    # )
+    assert (
+        paths["/test1/{val1}"]["get"]["parameters"][0]["description"]
+        == DESCRIPTION
+    )
 
     assert (
         paths["/test2/{val1}"]["get"]["parameters"][0]["description"]

--- a/tests/extensions/openapi/test_parameter.py
+++ b/tests/extensions/openapi/test_parameter.py
@@ -1,4 +1,5 @@
 from sanic import Request, Sanic, text
+from utils import get_spec
 
 from sanic_ext.extensions.openapi import openapi
 from sanic_ext.extensions.openapi.definitions import Parameter
@@ -40,22 +41,18 @@ def test_parameter_docstring(app: Sanic):
     async def handler3(request: Request, val1: int):
         return text("ok")
 
-    test_client = app.test_client
-    _, response = test_client.get("/docs/openapi.json")
-    paths = response.json.get("paths")
-
-    assert paths
+    spec = get_spec(app)
 
     assert (
-        paths["/test1/{val1}"]["get"]["parameters"][0]["description"]
+        spec["paths"]["/test1/{val1}"]["get"]["parameters"][0]["description"]
         == DESCRIPTION
     )
 
     assert (
-        paths["/test2/{val1}"]["get"]["parameters"][0]["description"]
+        spec["paths"]["/test2/{val1}"]["get"]["parameters"][0]["description"]
         == DESCRIPTION
     )
     assert (
-        paths["/test3/{val1}"]["get"]["parameters"][0]["description"]
+        spec["paths"]["/test3/{val1}"]["get"]["parameters"][0]["description"]
         == DESCRIPTION
     )

--- a/tests/extensions/openapi/test_parameter.py
+++ b/tests/extensions/openapi/test_parameter.py
@@ -43,7 +43,7 @@ def test_parameter_docstring(app: Sanic):
     test_client = app.test_client
     _, response = test_client.get("/docs/openapi.json")
     paths = response.json.get("paths")
-    print(paths)
+
     assert paths
 
     assert (

--- a/tests/extensions/openapi/test_parameter.py
+++ b/tests/extensions/openapi/test_parameter.py
@@ -1,6 +1,5 @@
 from sanic import Request, Sanic, text
 
-from sanic_ext import Extend
 from sanic_ext.extensions.openapi import openapi
 from sanic_ext.extensions.openapi.definitions import Parameter
 

--- a/tests/extensions/openapi/test_parameter.py
+++ b/tests/extensions/openapi/test_parameter.py
@@ -46,7 +46,6 @@ def test_parameter_docstring(app: Sanic):
     print(paths)
     assert paths
 
-    # Brocken test, only happen with the test client, need to be fixed.
     assert (
         paths["/test1/{val1}"]["get"]["parameters"][0]["description"]
         == DESCRIPTION

--- a/tests/extensions/openapi/utils.py
+++ b/tests/extensions/openapi/utils.py
@@ -1,0 +1,9 @@
+from typing import Dict
+
+from sanic import Sanic
+
+
+def get_spec(app: Sanic) -> Dict:
+    test_client = app.test_client
+    _, response = test_client.get("/docs/openapi.json")
+    return response.json


### PR DESCRIPTION
Related issue: https://github.com/sanic-org/sanic-ext/issues/18