### PR TITLE
Add flexibility in Extend declaration

### DIFF
--- a/sanic_ext/__init__.py
+++ b/sanic_ext/__init__.py
@@ -5,7 +5,7 @@ from sanic_ext.extensions.openapi import openapi
 from sanic_ext.extras.serializer.decorator import serializer
 from sanic_ext.extras.validation.decorator import validate
 
-__version__ = "21.9.3"
+__version__ = "21.12.0"
 __all__ = [
     "Config",
     "Extend",

--- a/sanic_ext/bootstrap.py
+++ b/sanic_ext/bootstrap.py
@@ -50,15 +50,15 @@ class Extend:
             )
 
         self.app = app
+        self.extensions = []
         self._injection_registry: Optional[InjectionRegistry] = None
-        app.ctx.ext = self
+        app._ext = self
 
         if not isinstance(config, Config):
             config = Config.from_dict(config or {})
         self.config = add_fallback_config(app, config, **kwargs)
 
-        if not extensions:
-            extensions = []
+        extensions = extensions or []
         if built_in_extensions:
             extensions.extend(
                 [
@@ -67,10 +67,14 @@ class Extend:
                     HTTPExtension,
                 ]
             )
-        init_logs = ["Sanic Extensions:"]
         for extclass in extensions[::-1]:
             extension = extclass(app, self.config)
             extension._startup(self)
+            self.extensions.append(extension)
+
+    def _display(self):
+        init_logs = ["Sanic Extensions:"]
+        for extension in self.extensions:
             init_logs.append(f"  > {extension.name} {extension.label()}")
 
         list(map(logger.info, init_logs))

--- a/sanic_ext/extensions/injection/extension.py
+++ b/sanic_ext/extensions/injection/extension.py
@@ -7,6 +7,9 @@ class InjectionExtension(Extension):
     name = "injection"
 
     def startup(self, bootstrap) -> None:
-        registry = InjectionRegistry()
-        add_injection(self.app, registry)
-        bootstrap._injection_registry = registry
+        self.registry = InjectionRegistry()
+        add_injection(self.app, self.registry)
+        bootstrap._injection_registry = self.registry
+
+    def label(self):
+        return f"[{self.registry.length}]"

--- a/sanic_ext/extensions/injection/registry.py
+++ b/sanic_ext/extensions/injection/registry.py
@@ -31,6 +31,10 @@ class InjectionRegistry:
             if isinstance(constructor, Constructor):
                 constructor.prepare(self, allowed_types)
 
+    @property
+    def length(self):
+        return len(self._registry)
+
 
 class SignatureRegistry:
     def __init__(self):

--- a/sanic_ext/extensions/openapi/extension.py
+++ b/sanic_ext/extensions/openapi/extension.py
@@ -12,9 +12,18 @@ class OpenAPIExtension(Extension):
 
     def label(self):
         if self.app.config.OAS:
-            name = f"{self.bp.name}.index"
-
-            if "SERVER_NAME" in self.app.config:
-                return f"[{self.app.url_for(name, _external=True)}]"
+            return self._make_url()
 
         return ""
+
+    def _make_url(self):
+        name = f"{self.bp.name}.index"
+        _server = (
+            None
+            if "SERVER_NAME" in self.app.config
+            else self.app.serve_location
+        ) or None
+        _external = bool(_server) or "SERVER_NAME" in self.app.config
+        return (
+            f"[{self.app.url_for(name, _external=_external, _server=_server)}]"
+        )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [
 dev_requires = ["black>=21.4b2", "flake8>=3.7.7", "isort>=5.0.0"]
 
 test_requires = [
-    "sanic_testing==0.7.0",
+    "sanic_testing>=0.8",
     "coverage",
     "pytest",
     "pytest-cov",

--- a/tests/extensions/injection/test_add_dependency.py
+++ b/tests/extensions/injection/test_add_dependency.py
@@ -28,7 +28,7 @@ def test_injection_of_matched_object(app):
         request.ctx.name = name
         return text(name.name)
 
-    app.ctx.ext.add_dependency(Name)
+    app.ext.add_dependency(Name)
 
     request, response = app.test_client.get("/person/george")
 
@@ -52,7 +52,7 @@ def test_injection_of_matched_object_as_deprecated_injection(app):
         "in v22.6. Please use 'ext.add_dependency' instead."
     )
     with pytest.warns(DeprecationWarning, match=message):
-        app.ctx.ext.injection(Name)
+        app.ext.injection(Name)
 
     request, response = app.test_client.get("/person/george")
 
@@ -71,7 +71,7 @@ def test_injection_of_simple_object(app):
         request.ctx.person = person
         return text(person.name)
 
-    app.ctx.ext.add_dependency(Person)
+    app.ext.add_dependency(Person)
 
     request, response = app.test_client.get("/person/george")
 
@@ -103,8 +103,8 @@ def test_injection_of_object_with_constructor(app):
             f"{person.person_id.person_id}\n{person.name}\n{person.age}"
         )
 
-    app.ctx.ext.add_dependency(Person, Person.create)
-    app.ctx.ext.add_dependency(PersonID)
+    app.ext.add_dependency(Person, Person.create)
+    app.ext.add_dependency(PersonID)
 
     request, response = app.test_client.get("/person/999")
 
@@ -132,7 +132,7 @@ def test_injection_on_cbv(app):
             request.ctx.name = name
             return text(name.name)
 
-    app.ctx.ext.add_dependency(Name)
+    app.ext.add_dependency(Name)
 
     for client in (app.test_client.get, app.test_client.post):
         request, response = client("/person/george")
@@ -169,9 +169,9 @@ def test_nested_dependencies(app):
             next(counter)
             return cls(b)
 
-    app.ctx.ext.add_dependency(A, A.create)
-    app.ctx.ext.add_dependency(B, B.create)
-    app.ctx.ext.add_dependency(C, C.create)
+    app.ext.add_dependency(A, A.create)
+    app.ext.add_dependency(B, B.create)
+    app.ext.add_dependency(C, C.create)
 
     @app.get("/")
     async def nested(request: Request, c: C):

--- a/tests/extensions/injection/test_dependency.py
+++ b/tests/extensions/injection/test_dependency.py
@@ -10,8 +10,8 @@ def test_dependency_added(app):
     foo = Foo()
     foobar = Foo()
 
-    app.ctx.ext.dependency(foo)
-    app.ctx.ext.dependency(foobar, name="something")
+    app.ext.dependency(foo)
+    app.ext.dependency(foobar, name="something")
 
     assert app.ctx._dependencies.foo is foo
     assert app.ctx._dependencies.something is foobar
@@ -20,7 +20,7 @@ def test_dependency_added(app):
 def test_dependency_injection(app):
     foo = Foo()
 
-    app.ctx.ext.dependency(foo)
+    app.ext.dependency(foo)
 
     @app.get("/getfoo")
     async def getfoo(request: Request, foo: Foo):


### PR DESCRIPTION
The main purpose of this is to make the integration into `Sanic` a little smoother. See https://github.com/sanic-org/sanic/pull/2308

For example, the output to logs at startup are moved to a separate location so that the app can be extended either before or at startup time, and still have them generated in a consistent location.