### PR TITLE
Temp Fix for openapi.definition with Parameter object

### DIFF
--- a/sanic_ext/extensions/openapi/openapi.py
+++ b/sanic_ext/extensions/openapi/openapi.py
@@ -404,6 +404,8 @@ def definition(
                 kwargs = {}
                 if isinstance(param, Parameter):
                     kwargs = param.fields
+                    if "in" in kwargs:
+                        kwargs["location"] = kwargs.pop("in")
                 elif isinstance(param, dict) and "name" in param:
                     kwargs = param
                 elif isinstance(param, str):

--- a/tests/extensions/openapi/test_parameter.py
+++ b/tests/extensions/openapi/test_parameter.py
@@ -52,8 +52,34 @@ def test_parameter_docstring(app: Sanic):
     async def handler3(request: Request, val1: int):
         return text("ok")
 
+    @app.route("/test4/<val1>")
+    @openapi.definition(
+        parameter={
+            "name": "val1",
+            "description": DESCRIPTION,
+            "required": True,
+            "schema": int,
+            "location": LOCATION,
+        }
+    )
+    async def handler4(request: Request, val1: int):
+        return text("ok")
+
+    @app.route("/test5/<val1>")
+    @openapi.definition(
+        parameter=Parameter(
+            name="val1",
+            schema=int,
+            location=LOCATION,
+            description=DESCRIPTION,
+            required=True,
+        )
+    )
+    async def handler5(request: Request, val1: int):
+        return text("ok")
+
     spec = get_spec(app)
-    for i in range(1, 4):
+    for i in range(1, 6):
         assert f"/test{i}/{{val1}}" in spec["paths"]
         parameter = spec["paths"][f"/test{i}/{{val1}}"]["get"]["parameters"][0]
         assert parameter["name"] == NAME


### PR DESCRIPTION
Related issue: https://github.com/sanic-org/sanic-ext/issues/11

`location` and `in` often mess up in the current version. I think this is only a temporary solution and we need to rethink this and make a rule like "using location everywhere except exporting it to the real docs" to declared when to use `location` and when to use `in`. Since `in` is a Python key word, making use of `location` everywhere except the real docs seems a good idea.