### PR TITLE
Add authorization to openapi

### DIFF
--- a/sanic_ext/bootstrap.py
+++ b/sanic_ext/bootstrap.py
@@ -14,6 +14,7 @@ from sanic_ext.extensions.base import Extension
 from sanic_ext.extensions.http.extension import HTTPExtension
 from sanic_ext.extensions.injection.extension import InjectionExtension
 from sanic_ext.extensions.injection.registry import InjectionRegistry
+from sanic_ext.extensions.openapi.builders import SpecificationBuilder
 from sanic_ext.extensions.openapi.extension import OpenAPIExtension
 from sanic_ext.utils.string import camel_to_snake
 
@@ -53,6 +54,7 @@ class Extend:
             )
 
         self.app = app
+        self._openapi: Optional[SpecificationBuilder] = None
         self.extensions = []
         self._injection_registry: Optional[InjectionRegistry] = None
         app._ext = self
@@ -113,3 +115,10 @@ class Extend:
             return obj
 
         self.add_dependency(obj.__class__, getter)
+
+    @property
+    def openapi(self) -> SpecificationBuilder:
+        if not self._openapi:
+            self._openapi = SpecificationBuilder()
+
+        return self._openapi

--- a/sanic_ext/extensions/openapi/builders.py
+++ b/sanic_ext/extensions/openapi/builders.py
@@ -313,22 +313,19 @@ class SpecificationBuilder:
         if isinstance(location, str):
             location = SecuritySchemeLocation(location)
 
-        kwargs = {
-            "type": type,
-            "scheme": scheme if type is SecuritySchemeType.HTTP else None,
-            "description": description,
-            "location": location
-            if type is SecuritySchemeType.API_KEY
-            else None,
-            "name": name if type is SecuritySchemeType.API_KEY else None,
-            "flows": flows if type is SecuritySchemeType.OAUTH2 else None,
-            "openIdConnectUrl": openid_connect_url
-            if type is SecuritySchemeType.OPEN_ID_CONNECT
-            else None,
-            "bearerFormat": bearer_format
-            if type is SecuritySchemeType.HTTP
-            else None,
-        }
+        kwargs: Dict[str, Any] = {"type": type, "description": description}
+
+        if type is SecuritySchemeType.API_KEY:
+            kwargs["location"] = location
+            kwargs["name"] = name
+        elif type is SecuritySchemeType.HTTP:
+            kwargs["scheme"] = scheme
+            kwargs["bearerFormat"] = bearer_format
+        elif type is SecuritySchemeType.OAUTH2:
+            kwargs["flows"] = flows
+        elif type is SecuritySchemeType.OPEN_ID_CONNECT:
+            kwargs["openIdConnectUrl"] = openid_connect_url
+
         self.add_component("securitySchemes", ident, SecurityScheme(**kwargs))  # type: ignore
 
     def raw(self, data):

--- a/sanic_ext/extensions/openapi/builders.py
+++ b/sanic_ext/extensions/openapi/builders.py
@@ -96,8 +96,11 @@ class OperationBuilder:
     ):
         self.responses[status] = Response.make(content, description, **kwargs)
 
-    def secure(self, *args, **kwargs):
-        items = {**{v: [] for v in args}, **kwargs}
+    def secured(self, *args, **kwargs):
+        if not kwargs and len(args) == 1 and isinstance(args[0], dict):
+            items = args[0]
+        else:
+            items = {**{v: [] for v in args}, **kwargs}
         gates = {}
 
         for name, params in items.items():
@@ -238,7 +241,7 @@ class SpecificationBuilder:
     def external(self, url: str, description: Optional[str] = None, **kwargs):
         self._external = ExternalDocumentation(url, description=description)
 
-    def secure(
+    def secured(
         self,
         name: str = None,
         value: Optional[Union[str, Sequence[str]]] = None,
@@ -352,10 +355,10 @@ class SpecificationBuilder:
         if "security" in data:
             for security in data["security"]:
                 if not security:
-                    self.secure()
+                    self.secured()
                 else:
                     for key, value in security.items():
-                        self.secure(key, value)
+                        self.secured(key, value)
 
         if "tags" in data:
             for tag in data["tags"]:

--- a/sanic_ext/extensions/openapi/builders.py
+++ b/sanic_ext/extensions/openapi/builders.py
@@ -326,7 +326,11 @@ class SpecificationBuilder:
         elif type is SecuritySchemeType.OPEN_ID_CONNECT:
             kwargs["openIdConnectUrl"] = openid_connect_url
 
-        self.add_component("securitySchemes", ident, SecurityScheme(**kwargs))  # type: ignore
+        self.add_component(
+            "securitySchemes",
+            ident,
+            SecurityScheme(**kwargs),
+        )  # type: ignore
 
     def raw(self, data):
         if "info" in data:

--- a/sanic_ext/extensions/openapi/builders.py
+++ b/sanic_ext/extensions/openapi/builders.py
@@ -314,7 +314,6 @@ class SpecificationBuilder:
             location = SecuritySchemeLocation(location)
 
         kwargs = {
-            "ident": ident,
             "type": type,
             "scheme": scheme if type is SecuritySchemeType.HTTP else None,
             "description": description,

--- a/sanic_ext/extensions/openapi/builders.py
+++ b/sanic_ext/extensions/openapi/builders.py
@@ -5,7 +5,13 @@ These are completely internal, so can be refactored if desired without concern
 for breaking user experience
 """
 from collections import defaultdict
-from typing import Optional
+from typing import Optional, Sequence, Union
+
+from sanic_ext.extensions.openapi.constants import (
+    SecuritySchemeAuthorization,
+    SecuritySchemeLocation,
+    SecuritySchemeType,
+)
 
 from ...utils.route import remove_nulls, remove_nulls_from_kwargs
 from .autodoc import YamlStyleParametersParser
@@ -15,6 +21,7 @@ from .definitions import (
     Contact,
     Dict,
     ExternalDocumentation,
+    Flows,
     Info,
     License,
     List,
@@ -24,6 +31,8 @@ from .definitions import (
     PathItem,
     RequestBody,
     Response,
+    SecurityRequirement,
+    SecurityScheme,
     Server,
     Tag,
 )
@@ -87,7 +96,7 @@ class OperationBuilder:
     ):
         self.responses[status] = Response.make(content, description, **kwargs)
 
-    def secured(self, *args, **kwargs):
+    def secure(self, *args, **kwargs):
         items = {**{v: [] for v in args}, **kwargs}
         gates = {}
 
@@ -156,6 +165,7 @@ class SpecificationBuilder:
     _license: License
     _paths: Dict[str, Dict[str, OperationBuilder]]
     _tags: Dict[str, Tag]
+    _security: List[SecurityRequirement]
     _components: Dict[str, Any]
     _servers: List[Server]
     # _components: ComponentsBuilder
@@ -178,6 +188,7 @@ class SpecificationBuilder:
         instance._paths = defaultdict(dict)
         instance._servers = []
         instance._tags = {}
+        instance._security = []
         instance._terms = None
         instance._title = None
         instance._urls = []
@@ -190,6 +201,10 @@ class SpecificationBuilder:
     @property
     def tags(self):
         return self._tags
+
+    @property
+    def security(self):
+        return self._security
 
     def url(self, value: str):
         self._urls.append(value)
@@ -222,6 +237,19 @@ class SpecificationBuilder:
 
     def external(self, url: str, description: Optional[str] = None, **kwargs):
         self._external = ExternalDocumentation(url, description=description)
+
+    def secure(
+        self,
+        name: str = None,
+        value: Optional[Union[str, Sequence[str]]] = None,
+    ):
+        if value is None:
+            value = []
+        elif isinstance(value, str):
+            value = [value]
+        else:
+            value = list(value)
+        self._security.append(SecurityRequirement(name=name, value=value))
 
     def contact(self, name: str = None, url: str = None, email: str = None):
         kwargs = remove_nulls_from_kwargs(name=name, url=url, email=email)
@@ -260,6 +288,47 @@ class SpecificationBuilder:
     def has_component(self, location: str, name: str) -> bool:
         return name in self._components.get(location, {})
 
+    def add_security_scheme(
+        self,
+        ident: str,
+        type: Union[str, SecuritySchemeType],
+        *,
+        bearer_format: Optional[str] = None,
+        description: Optional[str] = None,
+        flows: Optional[Union[Flows, Dict[str, Any]]] = None,
+        location: Union[
+            str, SecuritySchemeLocation
+        ] = SecuritySchemeLocation.HEADER,
+        name: str = "authorization",
+        openid_connect_url: Optional[str] = None,
+        scheme: Union[
+            str, SecuritySchemeAuthorization
+        ] = SecuritySchemeAuthorization.BEARER,
+    ):
+        if isinstance(type, str):
+            type = SecuritySchemeType(type)
+        if isinstance(location, str):
+            location = SecuritySchemeLocation(location)
+
+        kwargs = {
+            "name": name,
+            "type": type,
+            "scheme": scheme if type is SecuritySchemeType.HTTP else None,
+            "description": description,
+            "location": location
+            if type is SecuritySchemeType.API_KEY
+            else None,
+            "name": name if type is SecuritySchemeType.API_KEY else None,
+            "flows": flows if type is SecuritySchemeType.OAUTH2 else None,
+            "openIdConnectUrl": openid_connect_url
+            if type is SecuritySchemeType.OPEN_ID_CONNECT
+            else None,
+            "bearerFormat": bearer_format
+            if type is SecuritySchemeType.HTTP
+            else None,
+        }
+        self.add_component("securitySchemes", ident, SecurityScheme(**kwargs))  # type: ignore
+
     def raw(self, data):
         if "info" in data:
             self.describe(
@@ -281,7 +350,12 @@ class SpecificationBuilder:
                 self._components[location].update(component)
 
         if "security" in data:
-            ...
+            for security in data["security"]:
+                if not security:
+                    self.secure()
+                else:
+                    for key, value in security.items():
+                        self.secure(key, value)
 
         if "tags" in data:
             for tag in data["tags"]:
@@ -294,6 +368,7 @@ class SpecificationBuilder:
         info = self._build_info()
         paths = self._build_paths()
         tags = self._build_tags()
+        security = self._build_security()
 
         url_servers = getattr(self, "_urls", None)
         servers = self._servers
@@ -310,6 +385,7 @@ class SpecificationBuilder:
             paths,
             tags=tags,
             servers=servers,
+            security=security,
             components=components,
             externalDocs=self._external,
         )
@@ -342,3 +418,11 @@ class SpecificationBuilder:
             )
 
         return paths
+
+    def _build_security(self):
+        return [
+            {sec.fields["name"]: sec.fields["value"]}
+            if sec.fields["name"] is not None
+            else {}
+            for sec in self.security
+        ]

--- a/sanic_ext/extensions/openapi/builders.py
+++ b/sanic_ext/extensions/openapi/builders.py
@@ -314,7 +314,7 @@ class SpecificationBuilder:
             location = SecuritySchemeLocation(location)
 
         kwargs = {
-            "name": name,
+            "ident": ident,
             "type": type,
             "scheme": scheme if type is SecuritySchemeType.HTTP else None,
             "description": description,

--- a/sanic_ext/extensions/openapi/constants.py
+++ b/sanic_ext/extensions/openapi/constants.py
@@ -1,0 +1,36 @@
+from enum import Enum, auto
+
+
+class BaseEnum(Enum):
+    def _generate_next_value_(name, start, count, last_values):
+        parts = name.split("_")
+        return parts[0].lower() + "".join(part.title() for part in parts[1:])
+
+
+class SecuritySchemeType(BaseEnum):
+    API_KEY = auto()
+    HTTP = auto()
+    OAUTH2 = auto()
+    OPEN_ID_CONNECT = auto()
+
+
+class SecuritySchemeLocation(BaseEnum):
+    QUERY = auto()
+    HEADER = auto()
+    COOKIE = auto()
+
+
+class SecuritySchemeAuthorization(BaseEnum):
+    def _generate_next_value_(name, start, count, last_values):
+        return name.title()
+
+    BASIC = auto()
+    BEARER = auto()
+    DIGEST = auto()
+    HOBA = "HOBA"
+    MUTUAL = auto()
+    NEGOTIATE = auto()
+    OAUTH = "OAuth"
+    SCRAM_SHA_1 = "SCRAM-SHA-1"
+    SCRAM_SHA_256 = "SCRAM-SHA-256"
+    VAPID = "vapid"

--- a/sanic_ext/extensions/openapi/definitions.py
+++ b/sanic_ext/extensions/openapi/definitions.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from inspect import isclass
 from typing import Any, Dict, List, Optional, Type, Union, get_type_hints
 
+from click import password_option
 from sanic.exceptions import SanicException
 
 from .types import Definition, Schema
@@ -244,14 +245,36 @@ class PathItem(Definition):
     trace: Operation
 
 
+class Flow(Definition):
+    authorizationUrl: str
+    tokenUrl: str
+    refreshUrl: str
+    scopes: Dict[str, str]
+
+
+class Flows(Definition):
+    implicit: Flow
+    password: Flow
+    clientCredentials: Flow
+    authorizationCode: Flow
+
+
+class SecurityRequirement(Definition):
+    name: str
+    value: List[str]
+
+
 class SecurityScheme(Definition):
     type: str
-    description: str
-    scheme: str
     bearerFormat: str
-    name: str
+    description: str
+    flows: Flows
     location: str
+    name: str
     openIdConnectUrl: str
+    scheme: str
+
+    __nullable__ = None
 
     def __init__(self, type: str, **kwargs):
         super().__init__(type=type, **kwargs)
@@ -365,4 +388,5 @@ class OpenAPI(Definition):
     externalDocs: ExternalDocumentation
 
     def __init__(self, info: Info, paths: Dict[str, PathItem], **kwargs):
-        super().__init__(openapi="3.0.0", info=info, paths=paths, **kwargs)
+        use = {k: v for k, v in kwargs.items() if v is not None}
+        super().__init__(openapi="3.0.0", info=info, paths=paths, **use)

--- a/sanic_ext/extensions/openapi/definitions.py
+++ b/sanic_ext/extensions/openapi/definitions.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from inspect import isclass
 from typing import Any, Dict, List, Optional, Type, Union, get_type_hints
 
-from click import password_option
 from sanic.exceptions import SanicException
 
 from .types import Definition, Schema

--- a/sanic_ext/extensions/openapi/extension.py
+++ b/sanic_ext/extensions/openapi/extension.py
@@ -1,14 +1,24 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sanic_ext.extensions.openapi.builders import SpecificationBuilder
+
 from ..base import Extension
 from .blueprint import blueprint_factory
+
+if TYPE_CHECKING:
+    from sanic_ext import Extend
 
 
 class OpenAPIExtension(Extension):
     name = "openapi"
 
-    def startup(self, _) -> None:
+    def startup(self, bootstrap: Extend) -> None:
         if self.app.config.OAS:
             self.bp = blueprint_factory(self.app.config)
             self.app.blueprint(self.bp)
+            bootstrap._openapi = SpecificationBuilder()
 
     def label(self):
         if self.app.config.OAS:

--- a/sanic_ext/extensions/openapi/openapi.py
+++ b/sanic_ext/extensions/openapi/openapi.py
@@ -20,7 +20,6 @@ from typing import (
 
 from sanic import Blueprint
 from sanic.exceptions import InvalidUsage, SanicException
-
 from sanic_ext.extensions.openapi.builders import (
     OperationStore,
     SpecificationBuilder,
@@ -264,14 +263,9 @@ def response(
     return inner
 
 
-def secured(*args, **kwargs):
-    raise NotImplementedError(
-        "SecuritySchemas are not yet implemented in sanic-openapi 0.6.3, "
-        "hopefully they should be ready for the next release."
-    )
-
+def secure(*args, **kwargs):
     def inner(func):
-        OperationStore()[func].secured(*args, **kwargs)
+        OperationStore()[func].secure(*args, **kwargs)
         return func
 
     return inner

--- a/sanic_ext/extensions/openapi/openapi.py
+++ b/sanic_ext/extensions/openapi/openapi.py
@@ -20,6 +20,7 @@ from typing import (
 
 from sanic import Blueprint
 from sanic.exceptions import InvalidUsage, SanicException
+
 from sanic_ext.extensions.openapi.builders import (
     OperationStore,
     SpecificationBuilder,

--- a/sanic_ext/extensions/openapi/openapi.py
+++ b/sanic_ext/extensions/openapi/openapi.py
@@ -263,9 +263,9 @@ def response(
     return inner
 
 
-def secure(*args, **kwargs):
+def secured(*args, **kwargs):
     def inner(func):
-        OperationStore()[func].secure(*args, **kwargs)
+        OperationStore()[func].secured(*args, **kwargs)
         return func
 
     return inner
@@ -317,6 +317,7 @@ def definition(
             List[Union[Dict[str, Any], Response, Any]],
         ]
     ] = None,
+    secured: Optional[Dict[str, Any]] = None,
     validate: bool = False,
     body_argument: str = "body",
 ):
@@ -440,6 +441,9 @@ def definition(
                     kwargs["status"] = 200
 
                 func = glbl["response"](**kwargs)(func)
+
+        if secured:
+            func = glbl["secured"](secured)(func)
 
         return func
 

--- a/sanic_ext/extensions/openapi/types.py
+++ b/sanic_ext/extensions/openapi/types.py
@@ -34,7 +34,7 @@ class Definition:
 
     def serialize(self):
         return {
-            k: v
+            k: self._value(v)
             for k, v in _serialize(self.fields).items()
             if (
                 v
@@ -47,6 +47,12 @@ class Definition:
 
     def __str__(self):
         return json.dumps(self.serialize())
+
+    @staticmethod
+    def _value(value):
+        if isinstance(value, Enum):
+            return value.value
+        return value
 
 
 class Schema(Definition):

--- a/tests/extensions/openapi/test_security.py
+++ b/tests/extensions/openapi/test_security.py
@@ -1,4 +1,5 @@
 from sanic import Sanic
+
 from sanic_ext import openapi
 from tests.extensions.openapi.utils import get_path, get_spec
 

--- a/tests/extensions/openapi/test_security.py
+++ b/tests/extensions/openapi/test_security.py
@@ -1,0 +1,99 @@
+from sanic import Sanic
+from sanic_ext import openapi
+from tests.extensions.openapi.utils import get_path, get_spec
+
+
+def test_secured(app: Sanic):
+    @app.route("/one")
+    async def handler1(request):
+        """
+        openapi:
+        ---
+        security:
+            - foo: []
+        """
+
+    @app.route("/two")
+    @openapi.secured("foo")
+    @openapi.secured({"bar": []})
+    @openapi.secured(baz=[])
+    async def handler2(request):
+        ...
+
+    @app.route("/three")
+    @openapi.definition(secured="foo")
+    @openapi.definition(secured={"bar": []})
+    async def handler3(request):
+        ...
+
+    spec = get_path(app, "/one")
+    assert {"foo": []} in spec["security"]
+
+    spec = get_path(app, "/two")
+    assert {"foo": []} in spec["security"]
+    assert {"bar": []} in spec["security"]
+    assert {"baz": []} in spec["security"]
+
+    spec = get_path(app, "/three")
+    assert {"foo": []} in spec["security"]
+    assert {"bar": []} in spec["security"]
+
+
+def test_security_scheme(app: Sanic):
+    app.ext.openapi.add_security_scheme("api_key", "apiKey")
+    app.ext.openapi.add_security_scheme("token1", "http")
+    app.ext.openapi.add_security_scheme(
+        "token2", "http", scheme="bearer", bearer_format="JWT"
+    )
+    app.ext.openapi.add_security_scheme("oldschool", "http", scheme="basic")
+    app.ext.openapi.add_security_scheme(
+        "oa2",
+        "oauth2",
+        flows={
+            "implicit": {
+                "authorizationUrl": "http://example.com/auth",
+                "scopes": {
+                    "one:two": "something",
+                    "three:four": "something else",
+                },
+            }
+        },
+    )
+
+    spec = get_spec(app)
+    schemes = spec["components"]["securitySchemes"]
+
+    assert schemes["api_key"] == {
+        "type": "apiKey",
+        "name": "authorization",
+        "in": "header",
+    }
+    assert schemes["token1"] == {
+        "type": "http",
+        "scheme": "Bearer",
+    }
+    assert schemes["token2"] == {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+    }
+    assert schemes["oa2"] == {
+        "type": "oauth2",
+        "flows": {
+            "implicit": {
+                "authorizationUrl": "http://example.com/auth",
+                "scopes": {
+                    "one:two": "something",
+                    "three:four": "something else",
+                },
+            }
+        },
+    }
+
+
+def test_raw(app: Sanic):
+    app.ext.openapi.raw({"security": [{}, {"foo": []}]})
+
+    spec = get_spec(app)
+    assert {} in spec["security"]
+    assert {"foo": []} in spec["security"]

--- a/tests/extensions/openapi/utils.py
+++ b/tests/extensions/openapi/utils.py
@@ -1,9 +1,14 @@
-from typing import Dict
+from typing import Any, Dict
 
 from sanic import Sanic
 
 
-def get_spec(app: Sanic) -> Dict:
+def get_spec(app: Sanic) -> Dict[str, Any]:
     test_client = app.test_client
     _, response = test_client.get("/docs/openapi.json")
     return response.json
+
+
+def get_path(app: Sanic, path: str, method: str = "get") -> Dict[str, Any]:
+    spec = get_spec(app)
+    return spec["paths"][path][method.lower()]

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = {py38,py39,py310}, check
 python =
     3.8: py38
     3.9: py39, check
-    "3.10": py310
+    3.10: py310
 
 [testenv]
 deps =


### PR DESCRIPTION
This adds an API to work with OAS `SecuritySchemes` and add `security` to the application or operations.

- Adds access to the spec object on the extension bootstrapper:

```python
app.ext.openapi.describe(
    "Testing API", version="1.2.3", description="This is desc"
)
```

- Adds a `secure` method to enable application wide `security`:

```python
app.ext.openapi.secured()
app.ext.openapi.secured("my_token")
app.ext.openapi.secured(my_oauth2=["one:two"])
app.ext.openapi.secured({"my_oauth2": ["one:two"]})
```

- Or, you can put them on the operation level:

```python
@app.get("/")
@openapi.secured("my_token")
async def handler(request: Request):
    return json({"foo": "bar"})
```

- Adds a `add_security_scheme` to create `SecurityScheme` objects:

```python
app.ext.openapi.add_security_scheme("my_key", "apiKey")
app.ext.openapi.add_security_scheme(
    "token", "http", scheme="bearer", bearer_format="JWT"
)
app.ext.openapi.add_security_scheme(
    "my_oauth2",
    "oauth2",
    flows={
        "implicit": {
            "authorizationUrl": "http://example.com/auth",
            "scopes": {
                "one:two": "something",
                "three:four": "something else",
            },
        }
    },
)
```