### PR TITLE
Add support for multiple starts of extensions

### DIFF
--- a/sanic_ext/__init__.py
+++ b/sanic_ext/__init__.py
@@ -5,7 +5,7 @@ from sanic_ext.extensions.openapi import openapi
 from sanic_ext.extras.serializer.decorator import serializer
 from sanic_ext.extras.validation.decorator import validate
 
-__version__ = "21.12.2"
+__version__ = "21.12.3"
 __all__ = [
     "Config",
     "Extend",

--- a/sanic_ext/bootstrap.py
+++ b/sanic_ext/bootstrap.py
@@ -55,7 +55,7 @@ class Extend:
 
         self.app = app
         self._openapi: Optional[SpecificationBuilder] = None
-        self.extensions = []
+        self.extensions: List[Extension] = []
         self._injection_registry: Optional[InjectionRegistry] = None
         app._ext = self
         app.ctx._dependencies = SimpleNamespace()
@@ -73,10 +73,15 @@ class Extend:
                     HTTPExtension,
                 ]
             )
+
+        started = set()
         for extclass in extensions[::-1]:
+            if extclass in started:
+                continue
             extension = extclass(app, self.config)
             extension._startup(self)
             self.extensions.append(extension)
+            started.add(extclass)
 
     def _display(self):
         init_logs = ["Sanic Extensions:"]

--- a/sanic_ext/extensions/base.py
+++ b/sanic_ext/extensions/base.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Type
 
 from sanic.app import Sanic
 from sanic.exceptions import SanicException
+
 from sanic_ext.config import Config
 from sanic_ext.exceptions import InitError
 

--- a/sanic_ext/extensions/base.py
+++ b/sanic_ext/extensions/base.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Type
 
 from sanic.app import Sanic
 from sanic.exceptions import SanicException
-
 from sanic_ext.config import Config
 from sanic_ext.exceptions import InitError
 
@@ -19,14 +18,7 @@ class NoDuplicateDict(dict):  # type: ignore
 
 class Extension(ABC):
     _name_registry: Dict[str, Type[Extension]] = NoDuplicateDict()
-    _singleton = None
     name: str
-
-    def __new__(cls, *args, **kwargs):
-        if cls._singleton is None:
-            cls._singleton = super().__new__(cls)
-            cls._singleton._started = False
-        return cls._singleton
 
     def __init_subclass__(cls):
         if not getattr(cls, "name", None) or not cls.name.isalpha():
@@ -43,6 +35,7 @@ class Extension(ABC):
     def __init__(self, app: Sanic, config: Config) -> None:
         self.app = app
         self.config = config
+        self._started = False
 
     def _startup(self, bootstrap):
         if self._started:

--- a/sanic_ext/extensions/http/methods.py
+++ b/sanic_ext/extensions/http/methods.py
@@ -109,9 +109,10 @@ def add_auto_handlers(
             for group in app.router.groups.values():
                 if "OPTIONS" not in group.methods:
                     app.add_route(
-                        handler=partial(
-                            options_handler, methods=group.methods
-                        ),
+                        handler=openapi.definition(
+                            summary=clean_route_name(get_route.name).title(),
+                            description="Retrieve OPTIONS details",
+                        )(partial(options_handler, methods=group.methods)),
                         uri=group.uri,
                         methods=["OPTIONS"],
                         strict_slashes=group.strict,

--- a/tests/extensions/test_startup.py
+++ b/tests/extensions/test_startup.py
@@ -1,0 +1,30 @@
+from unittest.mock import Mock
+
+from sanic import Sanic
+from sanic_ext.extensions.base import Extension
+
+
+def test_multiple_extensions(bare_app: Sanic):
+    mock = Mock()
+
+    class FooExtension(Extension):
+        name = "foo"
+
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+
+        def startup(self, _) -> None:
+            mock()
+
+    class BarExtension(Extension):
+        name = "bar"
+
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+
+        def startup(self, _) -> None:
+            mock()
+
+    bare_app.extend(extensions=[FooExtension, BarExtension, BarExtension])
+
+    assert mock.call_count == 2

--- a/tests/extensions/test_startup.py
+++ b/tests/extensions/test_startup.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 from sanic import Sanic
+
 from sanic_ext.extensions.base import Extension
 
 


### PR DESCRIPTION
This PR removes the singleton pattern from extensions and localizes each startup to a single extension. By separating them, we should more easily allow for testing and multiple applications.