### PR TITLE
Move metadata to `setup.cfg`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 pretty:
-	black --line-length 79 --target-version=py39 sanic_ext tests
-	isort --line-length 79 --trailing-comma -m 3 sanic_ext tests
+	black sanic_ext tests
+	isort sanic_ext tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools<60.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 79
-target-version = ['py38']
+target-version = ['py38', 'py39', 'py310']
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
 [build-system]
 requires = ["setuptools<60.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 79
+target-version = ['py38']
+
+[tool.isort]
+profile = "black"
+src_paths = ["sanic_ext", "tests"]
+line_length = 79
+multi_line_output = 3
+include_trailing_comma = true

--- a/sanic_ext/__init__.py
+++ b/sanic_ext/__init__.py
@@ -1,3 +1,5 @@
+from importlib.metadata import version
+
 from sanic_ext.bootstrap import Extend
 from sanic_ext.config import Config
 from sanic_ext.extensions.http.cors import cors
@@ -5,7 +7,8 @@ from sanic_ext.extensions.openapi import openapi
 from sanic_ext.extras.serializer.decorator import serializer
 from sanic_ext.extras.validation.decorator import validate
 
-__version__ = "21.12.3"
+__version__ = version("sanic-ext")
+
 __all__ = [
     "Config",
     "Extend",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,3 @@
-[tool:pytest]
-;  addopts=--durations=0 --html=test_reports/report.html --self-contained-html --cov=sanic_openapi --cov-config .coveragerc --cov-report html
-
-[aliases]
-test=pytest
-
 [metadata]
 name = sanic-ext
 version = 21.12.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,29 @@
 
 [aliases]
 test=pytest
+
+[metadata]
+name = sanic-ext
+version = 21.12.3
+url = http://github.com/sanic-org/sanic-ext/
+license = MIT
+author = Sanic Community
+description = Extend your Sanic installation with some core functionality.
+long_description = file: README.rst
+platforms = any
+classifiers =
+    Development Status :: 3 - Alpha
+    Environment :: Web Environment
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+
+[options]
+include_package_data = True
+packages = find:
+install_requires =
+    pyyaml>=3.0.0
+
+[options.package_data]
+sanic_ext = extensions/openapi/ui/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,16 @@ install_requires =
 
 [options.package_data]
 sanic_ext = extensions/openapi/ui/*
+
+[options.extras_require]
+test = 
+    sanic_testing>=0.8
+    coverage
+    pytest
+    pytest-cov
+    tox
+dev = 
+    %(test)s
+    black>=21.4b2
+    flake8>=3.7.7
+    isort>=5.0.0

--- a/setup.py
+++ b/setup.py
@@ -2,22 +2,4 @@
 Sanic
 """
 from setuptools import setup
-
-
-dev_requires = ["black>=21.4b2", "flake8>=3.7.7", "isort>=5.0.0"]
-
-test_requires = [
-    "sanic_testing>=0.8",
-    "coverage",
-    "pytest",
-    "pytest-cov",
-    "tox",
-]
-
-
-setup(
-    extras_require={
-        "dev": dev_requires + test_requires,
-        "test": test_requires,
-    },
-)
+setup()

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,8 @@
 """
 Sanic
 """
-import codecs
-import os
-import re
+from setuptools import setup
 
-from setuptools import find_packages, setup
-
-install_requires = [
-    "pyyaml>=3.0.0",
-]
 
 dev_requires = ["black>=21.4b2", "flake8>=3.7.7", "isort>=5.0.0"]
 
@@ -21,43 +14,10 @@ test_requires = [
     "tox",
 ]
 
-project_root = os.path.dirname(os.path.abspath(__file__))
-
-with codecs.open(
-    os.path.join(project_root, "sanic_ext", "__init__.py"), "r", "latin1"
-) as fp:
-    try:
-        version = re.findall(
-            r"^__version__ = \"([^']+)\"\r?$", fp.read(), re.M
-        )[0]
-    except IndexError:
-        raise RuntimeError("Unable to determine version.")
-
-with open(os.path.join(project_root, "README.rst"), "r") as f:
-    long_description = f.read()
 
 setup(
-    name="sanic-ext",
-    version=version,
-    url="http://github.com/sanic-org/sanic-ext/",
-    license="MIT",
-    author="Sanic Community",
-    description="Extend your Sanic installation with some core functionality.",
-    long_description=long_description,
-    packages=find_packages(),
-    package_data={"sanic_ext": ["extensions/openapi/ui/*"]},
-    platforms="any",
-    install_requires=install_requires,
     extras_require={
         "dev": dev_requires + test_requires,
         "test": test_requires,
     },
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Environment :: Web Environment",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-    ],
 )

--- a/tests/extensions/openapi/test_body.py
+++ b/tests/extensions/openapi/test_body.py
@@ -4,10 +4,10 @@ from typing import Callable
 import pytest
 from sanic import Request, Sanic
 from sanic.response import text
-from utils import get_spec
 
 from sanic_ext import openapi
 from sanic_ext.extensions.openapi.definitions import RequestBody
+from utils import get_spec
 
 
 @dataclass

--- a/tests/extensions/openapi/test_parameter.py
+++ b/tests/extensions/openapi/test_parameter.py
@@ -1,8 +1,8 @@
 from sanic import Request, Sanic, text
-from utils import get_spec
 
 from sanic_ext.extensions.openapi import openapi
 from sanic_ext.extensions.openapi.definitions import Parameter
+from utils import get_spec
 
 
 def test_parameter(app: Sanic):

--- a/tests/extensions/openapi/test_tag.py
+++ b/tests/extensions/openapi/test_tag.py
@@ -1,8 +1,8 @@
 from sanic import Request, Sanic, text
-from utils import get_spec
 
 from sanic_ext.extensions.openapi import openapi
 from sanic_ext.extensions.openapi.definitions import Parameter, Tag
+from utils import get_spec
 
 
 def test_tag(app: Sanic):

--- a/tox.ini
+++ b/tox.ini
@@ -27,5 +27,5 @@ deps =
 
 commands =
     flake8 sanic_ext
-    black --check --line-length 79 --target-version=py39 sanic_ext tests
-    isort --check --line-length 79 --trailing-comma -m 3 sanic_ext tests
+    black --check sanic_ext tests
+    isort --check sanic_ext tests


### PR DESCRIPTION
Pros:
1. The complex logic in `setup.py` was removed and `setup.py` is kept at minimal. "Avoid executing arbitrary scripts and boilerplate code" (https://setuptools.pypa.io/en/latest/userguide/quickstart.html#transitioning-from-setup-py-to-setup-cfg).

Cons:
1. Few packages implemented this, so there might be unknown bugs or issues.
2. The Python community is switching to putting meta in `pyproject.toml` rather than `setup.cfg` or `setup.py` in the near future. So, we will probably need to switch again in the future. [PEP621](https://www.python.org/dev/peps/pep-0621/)

Any thought?

