### PR TITLE
Support dict annotations

### DIFF
--- a/sanic_ext/extensions/openapi/definitions.py
+++ b/sanic_ext/extensions/openapi/definitions.py
@@ -409,4 +409,4 @@ class OpenAPI(Definition):
 
     def __init__(self, info: Info, paths: Dict[str, PathItem], **kwargs):
         use = {k: v for k, v in kwargs.items() if v is not None}
-        super().__init__(openapi="3.0.0", info=info, paths=paths, **use)
+        super().__init__(openapi="3.0.3", info=info, paths=paths, **use)

--- a/sanic_ext/extensions/openapi/types.py
+++ b/sanic_ext/extensions/openapi/types.py
@@ -74,6 +74,7 @@ class Schema(Definition):
     anyOf: List[Definition]
     allOf: List[Definition]
 
+    additionalProperties: Dict[str, str]
     multipleOf: int
     maximum: int
     exclusiveMaximum: bool
@@ -158,6 +159,13 @@ class Schema(Definition):
             return Array(schema, **kwargs)
         elif _type == dict:
             return Object.make(value, **kwargs)
+        elif (
+            (is_generic(value) or is_generic(_type))
+            and origin == dict
+            and len(args) == 2
+        ):
+            kwargs["additionalProperties"] = Schema.make(args[1])
+            return Object(**kwargs)
         elif (is_generic(value) or is_generic(_type)) and origin == list:
             return Array(Schema.make(args[0]), **kwargs)
         elif _type is type(Enum):

--- a/tests/extensions/openapi/test_decorators.py
+++ b/tests/extensions/openapi/test_decorators.py
@@ -34,6 +34,7 @@ class BigFoo:
     nullable_multi: Optional[Union[str, int]]
     bar: Bar
     adict: Dict[str, Any]
+    bdict: Dict[str, bool]
     anything: Any
     choice: Choice
 
@@ -336,7 +337,16 @@ def test_parameter_decorator(app, decorator, expected):
                                             "name": {"type": "string"}
                                         },
                                     },
-                                    "adict": {"type": "object"},
+                                    "adict": {
+                                        "type": "object",
+                                        "additionalProperties": {},
+                                    },
+                                    "bdict": {
+                                        "type": "object",
+                                        "additionalProperties": {
+                                            "type": "boolean"
+                                        },
+                                    },
                                     "anything": {},
                                     "choice": {
                                         "type": "integer",


### PR DESCRIPTION
Support the usage of `dict` annotations:

```python
class Something:
    a: Dict[str, int]
    b: dict[str, bool]
```