### PR TITLE
Update Swagger UI Version; Adding Type Annotations

### DIFF
--- a/sanic_ext/config.py
+++ b/sanic_ext/config.py
@@ -34,7 +34,7 @@ class Config(SanicConfig):
         oas_ui_default: Optional[str] = "redoc",
         oas_ui_redoc: bool = True,
         oas_ui_swagger: bool = True,
-        oas_ui_swagger_version: str = "4.1.0",
+        oas_ui_swagger_version: str = "4.10.3",
         oas_uri_to_config: str = "/swagger-config",
         oas_uri_to_json: str = "/openapi.json",
         oas_uri_to_redoc: str = "/redoc",

--- a/sanic_ext/extensions/openapi/blueprint.py
+++ b/sanic_ext/extensions/openapi/blueprint.py
@@ -47,13 +47,13 @@ def blueprint_factory(config: Config):
                 bp.add_route(partial(index, page=page), "", name="index")
 
     @bp.get(config.OAS_URI_TO_JSON)
-    def spec(request):
+    def spec(request: Request):
         return json(SpecificationBuilder().build(request.app).serialize())
 
     if config.OAS_UI_SWAGGER:
 
         @bp.get(config.OAS_URI_TO_CONFIG)
-        def openapi_config(request):
+        def openapi_config(request: Request):
             return json(request.app.config.SWAGGER_UI_CONFIGURATION)
 
     @bp.before_server_start

--- a/sanic_ext/extensions/openapi/blueprint.py
+++ b/sanic_ext/extensions/openapi/blueprint.py
@@ -2,6 +2,7 @@ import inspect
 from functools import partial
 from os.path import abspath, dirname, realpath
 
+from sanic import Request
 from sanic.blueprints import Blueprint
 from sanic.config import Config
 from sanic.response import html, json
@@ -34,7 +35,7 @@ def blueprint_factory(config: Config):
             with open(html_path, "r") as f:
                 page = f.read()
 
-            def index(request, page):
+            def index(request: Request, page: str):
                 return html(
                     page.replace("__VERSION__", version).replace(
                         "__URL_PREFIX__", getattr(config, "OAS_URL_PREFIX")

--- a/sanic_ext/extensions/openapi/builders.py
+++ b/sanic_ext/extensions/openapi/builders.py
@@ -187,9 +187,9 @@ class SpecificationBuilder:
     _servers: List[Server]
     # _components: ComponentsBuilder
     # deliberately not included
-    _singleton = None
+    _singleton: SpecificationBuilder = None
 
-    def __new__(cls) -> Any:
+    def __new__(cls) -> SpecificationBuilder:
         if not cls._singleton:
             cls._singleton = super().__new__(cls)
             cls._setup_instance(cls._singleton)

--- a/sanic_ext/extensions/openapi/builders.py
+++ b/sanic_ext/extensions/openapi/builders.py
@@ -187,7 +187,7 @@ class SpecificationBuilder:
     _servers: List[Server]
     # _components: ComponentsBuilder
     # deliberately not included
-    _singleton: SpecificationBuilder = None
+    _singleton: Optional[SpecificationBuilder] = None
 
     def __new__(cls) -> SpecificationBuilder:
         if not cls._singleton:

--- a/sanic_ext/extensions/openapi/ui/swagger.html
+++ b/sanic_ext/extensions/openapi/ui/swagger.html
@@ -5,7 +5,7 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" type="text/css"
-            href="//cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui.min.css">
+            href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui.min.css">
         <title>OpenAPI Swagger</title>
         <style>
             body {
@@ -16,9 +16,9 @@
 
     <body>
         <div id="openapi">
-            <script src="//cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui-bundle.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui-bundle.min.js"></script>
             <script
-                src="//cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui-standalone-preset.min.js"></script>
+                src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui-standalone-preset.min.js"></script>
             <script>
                 window.onload = function () {
                     const ui = SwaggerUIBundle({


### PR DESCRIPTION
1. Protocol type (https) added to CDN URLs, to ensure security transportation and to resolve the warnings by IDE (VS Code).
2. Pump up Swagger UI Version from 4.1.0 to 4.10.3. 
4.10.3 is currently the most popular version of Swagger UI and it resolved a security issue compared with 4.1.0
(The security issue was resolved in all versions >= 4.1.3, details: https://security.snyk.io/vuln/SNYK-JS-SWAGGERUI-2314885)
Unit testing passed but it probably needs more manual (eye) testing due to the natures of UI stuff, will be done in days.
3. Added some type annotations to make the dev experience with IDEs better.