### PR TITLE
Fix issue #92 - @validate decorator not working for class-based views

### DIFF
--- a/sanic_ext/extras/validation/decorator.py
+++ b/sanic_ext/extras/validation/decorator.py
@@ -3,9 +3,9 @@ from inspect import isawaitable
 from typing import Callable, Optional, Type, Union
 
 from sanic import Request
+from sanic.exceptions import SanicException
 
 from sanic_ext.exceptions import InitError
-from sanic.exceptions import SanicException
 
 from .setup import do_validation, generate_schema
 
@@ -33,13 +33,13 @@ def validate(
     def decorator(f):
         @wraps(f)
         async def decorated_function(*args, **kwargs):
-            
+
             if args and isinstance(args[0], Request):
                 request: Request = args[0]
             elif len(args) > 1:
                 request: Request = args[1]
             else:
-                raise SanicException('Request could not be found')
+                raise SanicException("Request could not be found")
 
             if schemas["json"]:
                 await do_validation(

--- a/sanic_ext/extras/validation/decorator.py
+++ b/sanic_ext/extras/validation/decorator.py
@@ -5,6 +5,7 @@ from typing import Callable, Optional, Type, Union
 from sanic import Request
 
 from sanic_ext.exceptions import InitError
+from sanic.exceptions import SanicException
 
 from .setup import do_validation, generate_schema
 
@@ -33,7 +34,12 @@ def validate(
         @wraps(f)
         async def decorated_function(*args, **kwargs):
             
-            request: Request = args[0] if args and type(args[0]) == Request else args[1]
+            if args and type(args[0]) == Request:
+                request: Request = args[0]
+            elif len(args) > 1:
+                request: Request = [1]
+            else:
+                raise SanicException('Request could not be found')
 
             if schemas["json"]:
                 await do_validation(

--- a/sanic_ext/extras/validation/decorator.py
+++ b/sanic_ext/extras/validation/decorator.py
@@ -31,7 +31,9 @@ def validate(
 
     def decorator(f):
         @wraps(f)
-        async def decorated_function(request: Request, *args, **kwargs):
+        async def decorated_function(*args, **kwargs):
+            
+            request: Request = args[0] if args and type(args[0]) == Request else args[1]
 
             if schemas["json"]:
                 await do_validation(
@@ -66,7 +68,7 @@ def validate(
                     allow_multiple=True,
                     allow_coerce=True,
                 )
-            retval = f(request, *args, **kwargs)
+            retval = f(*args, **kwargs)
             if isawaitable(retval):
                 retval = await retval
             return retval

--- a/sanic_ext/extras/validation/decorator.py
+++ b/sanic_ext/extras/validation/decorator.py
@@ -34,7 +34,7 @@ def validate(
         @wraps(f)
         async def decorated_function(*args, **kwargs):
             
-            if args and type(args[0]) == Request:
+            if args and isinstance(args[0], Request):
                 request: Request = args[0]
             elif len(args) > 1:
                 request: Request = args[1]

--- a/sanic_ext/extras/validation/decorator.py
+++ b/sanic_ext/extras/validation/decorator.py
@@ -37,7 +37,7 @@ def validate(
             if args and type(args[0]) == Request:
                 request: Request = args[0]
             elif len(args) > 1:
-                request: Request = [1]
+                request: Request = args[1]
             else:
                 raise SanicException('Request could not be found')
 


### PR DESCRIPTION
This small PR fix the issue described in https://github.com/sanic-org/sanic-ext/issues/92

TLDR: We didn't handle the class-based view case with the @validate decorator, so I changed the decorator to not use the first arg as the request by default.
 