### PR TITLE
support validate  HTTPMethodView decorators

### DIFF
--- a/sanic_ext/extras/validation/decorator.py
+++ b/sanic_ext/extras/validation/decorator.py
@@ -1,23 +1,22 @@
 from functools import wraps
 from inspect import isawaitable
-from typing import Callable, Optional, Type, Union
+from typing import Callable, Optional, Type, Union, Iterable
 
 from sanic import Request
 from sanic.exceptions import SanicException
 
 from sanic_ext.exceptions import InitError
-
 from .setup import do_validation, generate_schema
 
 
 def validate(
-    json: Optional[Union[Callable[[Request], bool], Type[object]]] = None,
-    form: Optional[Union[Callable[[Request], bool], Type[object]]] = None,
-    query: Optional[Union[Callable[[Request], bool], Type[object]]] = None,
-    body_argument: str = "body",
-    query_argument: str = "query",
+        json: Optional[Union[Callable[[Request], bool], Type[object]]] = None,
+        form: Optional[Union[Callable[[Request], bool], Type[object]]] = None,
+        query: Optional[Union[Callable[[Request], bool], Type[object]]] = None,
+        body_argument: str = "body",
+        query_argument: str = "query",
+        method: Iterable[str] = None
 ):
-
     schemas = {
         key: generate_schema(param)
         for key, param in (
@@ -41,39 +40,41 @@ def validate(
             else:
                 raise SanicException("Request could not be found")
 
-            if schemas["json"]:
-                await do_validation(
-                    model=json,
-                    data=request.json,
-                    schema=schemas["json"],
-                    request=request,
-                    kwargs=kwargs,
-                    body_argument=body_argument,
-                    allow_multiple=False,
-                    allow_coerce=False,
-                )
-            elif schemas["form"]:
-                await do_validation(
-                    model=form,
-                    data=request.form,
-                    schema=schemas["form"],
-                    request=request,
-                    kwargs=kwargs,
-                    body_argument=body_argument,
-                    allow_multiple=True,
-                    allow_coerce=False,
-                )
-            elif schemas["query"]:
-                await do_validation(
-                    model=query,
-                    data=request.args,
-                    schema=schemas["query"],
-                    request=request,
-                    kwargs=kwargs,
-                    body_argument=query_argument,
-                    allow_multiple=True,
-                    allow_coerce=True,
-                )
+            if method and request.method not in method:
+
+                if schemas["json"]:
+                    await do_validation(
+                        model=json,
+                        data=request.json,
+                        schema=schemas["json"],
+                        request=request,
+                        kwargs=kwargs,
+                        body_argument=body_argument,
+                        allow_multiple=False,
+                        allow_coerce=False,
+                    )
+                elif schemas["form"]:
+                    await do_validation(
+                        model=form,
+                        data=request.form,
+                        schema=schemas["form"],
+                        request=request,
+                        kwargs=kwargs,
+                        body_argument=body_argument,
+                        allow_multiple=True,
+                        allow_coerce=False,
+                    )
+                elif schemas["query"]:
+                    await do_validation(
+                        model=query,
+                        data=request.args,
+                        schema=schemas["query"],
+                        request=request,
+                        kwargs=kwargs,
+                        body_argument=query_argument,
+                        allow_multiple=True,
+                        allow_coerce=True,
+                    )
             retval = f(*args, **kwargs)
             if isawaitable(retval):
                 retval = await retval


### PR DESCRIPTION
I suggest set a argument method,   for example:

```
class UserView(HTTPMethodView):
    decorators = [validate(json=...)]

    def get(self, request):
        ...

    def post(self, request, body):
        ...
```

the get method will also completely execute the decorators.
and it's will raise ValidationError

```
if method and request.method not in method:
    return f(*args, **kwargs)
if schemas["json"]:
    ...
elif schemas["form"]:
    ...
```

I think It's can solved this problem. what do you think? 