### PR TITLE
Pass cors domains as list

### DIFF
--- a/sanic_ext/config.py
+++ b/sanic_ext/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from sanic import Sanic
 from sanic.config import Config as SanicConfig
@@ -17,7 +17,7 @@ class Config(SanicConfig):
         cors_expose_headers: str = "",
         cors_max_age: int = 5,
         cors_methods: str = "",
-        cors_origins: str = "",
+        cors_origins: Union[str, List[str]] = "",
         cors_send_wildcard: bool = False,
         cors_supports_credentials: bool = False,
         cors_vary_header: bool = True,

--- a/sanic_ext/extensions/http/cors.py
+++ b/sanic_ext/extensions/http/cors.py
@@ -299,9 +299,11 @@ def _get_allow_origins(app: Sanic) -> Tuple[re.Pattern, ...]:
 
 
 def _parse_allow_origins(
-    value: Union[str, re.Pattern]
+    value: Union[str, re.Pattern, List[Union[str, re.Pattern]]]
 ) -> Tuple[re.Pattern, ...]:
-    origins: Optional[Union[List[str], List[re.Pattern]]] = None
+    origins: Optional[
+        Union[List[str], List[re.Pattern], List[Union[str, re.Pattern]]]
+    ] = None
     if value and isinstance(value, str):
         if value == "*":
             origins = [WILDCARD_PATTERN]
@@ -309,9 +311,13 @@ def _parse_allow_origins(
             origins = value.split(",")
     elif isinstance(value, re.Pattern):
         origins = [value]
+    elif isinstance(value, list):
+        origins = value
 
     return tuple(
-        pattern if isinstance(pattern, re.Pattern) else re.compile(pattern)
+        pattern
+        if isinstance(pattern, re.Pattern)
+        else re.compile(re.escape(pattern))
         for pattern in (origins or [])
     )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sanic-ext
-version = 22.6.1
+version = 22.6.2
 url = http://github.com/sanic-org/sanic-ext/
 license = MIT
 author = Sanic Community


### PR DESCRIPTION
This was an intended feature that has not been working.

```python
app.config.CORS_ORIGINS = [...]
```