### PR TITLE
Add HTML title and css configuration to Redoc/Swagger

### DIFF
--- a/sanic_ext/config.py
+++ b/sanic_ext/config.py
@@ -44,7 +44,9 @@ class Config(SanicConfig):
         oas_path_to_swagger_html: Optional[str] = None,
         oas_ui_default: Optional[str] = "redoc",
         oas_ui_redoc: bool = True,
+        oas_ui_redoc_html_title: str = "ReDoc",
         oas_ui_swagger: bool = True,
+        oas_ui_swagger_html_title: str = "OpenAPI Swagger",
         oas_ui_swagger_version: str = "4.10.3",
         oas_uri_to_config: str = "/swagger-config",
         oas_uri_to_json: str = "/openapi.json",
@@ -91,7 +93,9 @@ class Config(SanicConfig):
         self.OAS_PATH_TO_SWAGGER_HTML = oas_path_to_swagger_html
         self.OAS_UI_DEFAULT = oas_ui_default
         self.OAS_UI_REDOC = oas_ui_redoc
+        self.OAS_UI_REDOC_HTML_TITLE = oas_ui_redoc_html_title
         self.OAS_UI_SWAGGER = oas_ui_swagger
+        self.OAS_UI_SWAGGER_HTML_TITLE = oas_ui_swagger_html_title
         self.OAS_UI_SWAGGER_VERSION = oas_ui_swagger_version
         self.OAS_URI_TO_CONFIG = oas_uri_to_config
         self.OAS_URI_TO_JSON = oas_uri_to_json

--- a/sanic_ext/config.py
+++ b/sanic_ext/config.py
@@ -45,8 +45,10 @@ class Config(SanicConfig):
         oas_ui_default: Optional[str] = "redoc",
         oas_ui_redoc: bool = True,
         oas_ui_redoc_html_title: str = "ReDoc",
+        oas_ui_redoc_custom_css: str = "",
         oas_ui_swagger: bool = True,
         oas_ui_swagger_html_title: str = "OpenAPI Swagger",
+        oas_ui_swagger_custom_css: str = "",
         oas_ui_swagger_version: str = "4.10.3",
         oas_uri_to_config: str = "/swagger-config",
         oas_uri_to_json: str = "/openapi.json",
@@ -94,8 +96,10 @@ class Config(SanicConfig):
         self.OAS_UI_DEFAULT = oas_ui_default
         self.OAS_UI_REDOC = oas_ui_redoc
         self.OAS_UI_REDOC_HTML_TITLE = oas_ui_redoc_html_title
+        self.OAS_UI_REDOC_CUSTOM_CSS = oas_ui_redoc_custom_css
         self.OAS_UI_SWAGGER = oas_ui_swagger
         self.OAS_UI_SWAGGER_HTML_TITLE = oas_ui_swagger_html_title
+        self.OAS_UI_SWAGGER_CUSTOM_CSS = oas_ui_swagger_custom_css
         self.OAS_UI_SWAGGER_VERSION = oas_ui_swagger_version
         self.OAS_URI_TO_CONFIG = oas_uri_to_config
         self.OAS_URI_TO_JSON = oas_uri_to_json

--- a/sanic_ext/extensions/openapi/blueprint.py
+++ b/sanic_ext/extensions/openapi/blueprint.py
@@ -32,6 +32,7 @@ def blueprint_factory(config: Config):
             uri = getattr(config, f"OAS_URI_TO_{ui}".upper())
             version = getattr(config, f"OAS_UI_{ui}_VERSION".upper(), "")
             html_title = getattr(config, f"OAS_UI_{ui}_HTML_TITLE".upper())
+            custom_css = getattr(config, f"OAS_UI_{ui}_CUSTOM_CSS".upper())
             html_path = path if path else f"{dir_path}/{ui}.html"
 
             with open(html_path, "r") as f:
@@ -42,6 +43,7 @@ def blueprint_factory(config: Config):
                     page.replace("__VERSION__", version)
                         .replace("__URL_PREFIX__", getattr(config, "OAS_URL_PREFIX"))
                         .replace("__HTML_TITLE__", html_title)
+                        .replace("__HTML_CUSTOM_CSS__", custom_css)
                 )
 
             bp.add_route(partial(index, page=page), uri, name=ui)

--- a/sanic_ext/extensions/openapi/blueprint.py
+++ b/sanic_ext/extensions/openapi/blueprint.py
@@ -38,7 +38,7 @@ def blueprint_factory(config: Config):
             with open(html_path, "r") as f:
                 page = f.read()
 
-            def index(request: Request, page: str):
+            def index(request: Request, page: str, html_title: str, custom_css: str):
                 return html(
                     page.replace("__VERSION__", version)
                         .replace("__URL_PREFIX__", getattr(config, "OAS_URL_PREFIX"))
@@ -46,9 +46,11 @@ def blueprint_factory(config: Config):
                         .replace("__HTML_CUSTOM_CSS__", custom_css)
                 )
 
-            bp.add_route(partial(index, page=page), uri, name=ui)
+            bp.add_route(partial(index, page=page,
+                         html_title=html_title, custom_css=custom_css), uri, name=ui)
             if config.OAS_UI_DEFAULT and config.OAS_UI_DEFAULT == ui:
-                bp.add_route(partial(index, page=page), "", name="index")
+                bp.add_route(partial(index, page=page,
+                                     html_title=html_title, custom_css=custom_css), "", name="index")
 
     @bp.get(config.OAS_URI_TO_JSON)
     def spec(request: Request):

--- a/sanic_ext/extensions/openapi/blueprint.py
+++ b/sanic_ext/extensions/openapi/blueprint.py
@@ -31,6 +31,7 @@ def blueprint_factory(config: Config):
             path = getattr(config, f"OAS_PATH_TO_{ui}_HTML".upper())
             uri = getattr(config, f"OAS_URI_TO_{ui}".upper())
             version = getattr(config, f"OAS_UI_{ui}_VERSION".upper(), "")
+            html_title = getattr(config, f"OAS_UI_{ui}_HTML_TITLE".upper())
             html_path = path if path else f"{dir_path}/{ui}.html"
 
             with open(html_path, "r") as f:
@@ -38,9 +39,9 @@ def blueprint_factory(config: Config):
 
             def index(request: Request, page: str):
                 return html(
-                    page.replace("__VERSION__", version).replace(
-                        "__URL_PREFIX__", getattr(config, "OAS_URL_PREFIX")
-                    )
+                    page.replace("__VERSION__", version)
+                        .replace("__URL_PREFIX__", getattr(config, "OAS_URL_PREFIX"))
+                        .replace("__HTML_TITLE__", html_title)
                 )
 
             bp.add_route(partial(index, page=page), uri, name=ui)

--- a/sanic_ext/extensions/openapi/ui/redoc.html
+++ b/sanic_ext/extensions/openapi/ui/redoc.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-
     <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -12,8 +11,9 @@
                 padding: 0;
             }
         </style>
-
+    </head>
     <body>
         <redoc spec-url="__URL_PREFIX__/openapi.json"></redoc>
-        <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+        <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
     </body>
+</html>

--- a/sanic_ext/extensions/openapi/ui/redoc.html
+++ b/sanic_ext/extensions/openapi/ui/redoc.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
-        <title>ReDoc</title>
+        <title>__HTML_TITLE__</title>
         <style>
             body {
                 margin: 0;

--- a/sanic_ext/extensions/openapi/ui/redoc.html
+++ b/sanic_ext/extensions/openapi/ui/redoc.html
@@ -10,6 +10,7 @@
                 margin: 0;
                 padding: 0;
             }
+            __HTML_CUSTOM_CSS__
         </style>
     </head>
     <body>

--- a/sanic_ext/extensions/openapi/ui/swagger.html
+++ b/sanic_ext/extensions/openapi/ui/swagger.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui.min.css">
-        <title>OpenAPI Swagger</title>
+        <title>__HTML_TITLE__</title>
         <style>
             body {
                 margin: 0;

--- a/sanic_ext/extensions/openapi/ui/swagger.html
+++ b/sanic_ext/extensions/openapi/ui/swagger.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
-
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" type="text/css"
-            href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui.min.css">
+        <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui.min.css">
         <title>OpenAPI Swagger</title>
         <style>
             body {
@@ -13,28 +11,28 @@
                 padding: 0;
             }
         </style>
-
+    </head>
     <body>
-        <div id="openapi">
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui-bundle.min.js"></script>
-            <script
-                src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui-standalone-preset.min.js"></script>
-            <script>
-                window.onload = function () {
-                    const ui = SwaggerUIBundle({
-                        url: "__URL_PREFIX__/openapi.json",
-                        dom_id: "#openapi",
-                        configUrl: "__URL_PREFIX__/swagger-config",
-                        deepLinking: true,
-                        presets: [
-                            SwaggerUIBundle.presets.apis,
-                            SwaggerUIStandalonePreset
-                        ],
-                        plugins: [
-                            SwaggerUIBundle.plugins.DownloadUrl
-                        ],
-                        layout: "StandaloneLayout"
-                    })
-                }
-            </script>
+        <div id="openapi"></div>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui-bundle.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/__VERSION__/swagger-ui-standalone-preset.min.js"></script>
+        <script>
+            window.onload = function () {
+                const ui = SwaggerUIBundle({
+                    url: "__URL_PREFIX__/openapi.json",
+                    dom_id: "#openapi",
+                    configUrl: "__URL_PREFIX__/swagger-config",
+                    deepLinking: true,
+                    presets: [
+                        SwaggerUIBundle.presets.apis,
+                        SwaggerUIStandalonePreset
+                    ],
+                    plugins: [
+                        SwaggerUIBundle.plugins.DownloadUrl
+                    ],
+                    layout: "StandaloneLayout"
+                })
+            }
+        </script>
     </body>
+</html>

--- a/sanic_ext/extensions/openapi/ui/swagger.html
+++ b/sanic_ext/extensions/openapi/ui/swagger.html
@@ -10,6 +10,7 @@
                 margin: 0;
                 padding: 0;
             }
+            __HTML_CUSTOM_CSS__
         </style>
     </head>
     <body>


### PR DESCRIPTION
Changes:
- formatted HTML file correctly (added end tags)
- made it possible to change the HTML title and add custom CSS (for styling the docs page)
  - had to pass the variables to the function or else the swagger title/css was shared with redoc 

This should be added in the docs, although unsure how to change them/where they are.