### PR TITLE
fix: injecting async dependencies

### DIFF
--- a/sanic_ext/extensions/injection/constructor.py
+++ b/sanic_ext/extensions/injection/constructor.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from inspect import isawaitable
+from inspect import iscoroutine
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -44,7 +44,7 @@ class Constructor:
             if self.pass_kwargs:
                 args.update(kwargs)
             retval = self.func(request, **args)
-            if isawaitable(retval):
+            if iscoroutine(retval):
                 retval = await retval
             return retval
         except TypeError as e:
@@ -136,6 +136,6 @@ async def do_cast(_type, constructor, request, **kwargs):
     args = [request] if constructor else []
 
     retval = cast(*args, **kwargs)
-    if isawaitable(retval):
+    if iscoroutine(retval):
         retval = await retval
     return retval

--- a/tests/extensions/injection/test_add_dependency.py
+++ b/tests/extensions/injection/test_add_dependency.py
@@ -246,7 +246,7 @@ def test_injection_on_websocket(app):
 
 
 def test_injection_of_awaitable_variable_in_do_cast(app):
-    ''' Test for do_cast() iscoroutine() check '''
+    """Test for do_cast() iscoroutine() check"""
 
     @app.get("/person/<name:str>")
     def handler(request, name: AsyncName):
@@ -263,7 +263,7 @@ def test_injection_of_awaitable_variable_in_do_cast(app):
 
 
 def test_injection_of_awaitable_variable_in_call(app):
-    ''' Test for __call__() iscoroutine() check '''
+    """Test for __call__() iscoroutine() check"""
 
     @app.get("/person/<name:str>")
     def handler(request, name: AsyncName):


### PR DESCRIPTION
Changes:
- changed usage of `isawaitable` to `iscoroutine`
- added tests for the case where the dependency itself is an async variable (related to `do_call()`) and if it comes from a function (related to `__call__()`)

Related issue:
closes #112 