### PR TITLE
feat: serve oauth2-redirect.html with swagger

### DIFF
--- a/sanic_ext/config.py
+++ b/sanic_ext/config.py
@@ -35,6 +35,7 @@ class Config(SanicConfig):
         oas_ui_redoc: bool = True,
         oas_ui_swagger: bool = True,
         oas_ui_swagger_version: str = "4.10.3",
+        oas_ui_swagger_oauth2_redirect: str = "/oauth2-redirect.html",
         oas_uri_to_config: str = "/swagger-config",
         oas_uri_to_json: str = "/openapi.json",
         oas_uri_to_redoc: str = "/redoc",
@@ -73,6 +74,7 @@ class Config(SanicConfig):
         self.OAS_UI_REDOC = oas_ui_redoc
         self.OAS_UI_SWAGGER = oas_ui_swagger
         self.OAS_UI_SWAGGER_VERSION = oas_ui_swagger_version
+        self.OAS_UI_SWAGGER_OAUTH2_REDIRECT = oas_ui_swagger_oauth2_redirect
         self.OAS_URI_TO_CONFIG = oas_uri_to_config
         self.OAS_URI_TO_JSON = oas_uri_to_json
         self.OAS_URI_TO_REDOC = oas_uri_to_redoc


### PR DESCRIPTION
Changes:
- fetches oauth2-redirect.html file (using urllib instead of requests to not bring in another package) and serves it according to the config

Related:
closes #113 