### PR TITLE
Add py.typed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,9 @@ install_requires =
     pyyaml>=3.0.0
 
 [options.package_data]
-sanic_ext = extensions/openapi/ui/*
+sanic_ext =
+    py.typed
+    extensions/openapi/ui/*
 
 [options.extras_require]
 test =


### PR DESCRIPTION
This PR adds the [py.typed](https://peps.python.org/pep-0561/) file.

See also sanic-org/sanic#1970