### PR TITLE
added url_for function for use in Jinja2 templates

### DIFF
--- a/sanic_ext/bootstrap.py
+++ b/sanic_ext/bootstrap.py
@@ -103,6 +103,9 @@ class Extend:
             self.extensions.append(extension)
             started.add(ext)
 
+        if TEMPLATING_ENABLED:
+            app.ext.templating.environment.globals['url_for'] = app.url_for
+
     def _display(self):
         init_logs = ["Sanic Extensions:"]
         for extension in self.extensions:

--- a/sanic_ext/bootstrap.py
+++ b/sanic_ext/bootstrap.py
@@ -103,8 +103,8 @@ class Extend:
             self.extensions.append(extension)
             started.add(ext)
 
-        if TEMPLATING_ENABLED:
-            app.ext.templating.environment.globals['url_for'] = app.url_for
+        if built_in_extensions and TEMPLATING_ENABLED:
+            app.ext.templating.environment.globals["url_for"] = app.url_for
 
     def _display(self):
         init_logs = ["Sanic Extensions:"]

--- a/sanic_ext/bootstrap.py
+++ b/sanic_ext/bootstrap.py
@@ -106,9 +106,6 @@ class Extend:
             self.extensions.append(extension)
             started.add(ext)
 
-        if built_in_extensions and TEMPLATING_ENABLED:
-            app.ext.templating.environment.globals["url_for"] = app.url_for
-
     def _display(self):
         init_logs = ["Sanic Extensions:"]
         for extension in self.extensions:

--- a/sanic_ext/extensions/templating/extension.py
+++ b/sanic_ext/extensions/templating/extension.py
@@ -39,6 +39,7 @@ class TemplatingExtension(Extension):
             bootstrap.templating = Templating(
                 environment=bootstrap.environment, config=self.config
             )
+        bootstrap.templating.environment.globals["url_for"] = self.app.url_for
 
     def label(self):
         return f"jinja2=={__version__}"

--- a/tests/extensions/templating/test_templating.py
+++ b/tests/extensions/templating/test_templating.py
@@ -96,3 +96,17 @@ def test_config_templating_dir():
     assert app.ext.templating.environment.get_template(
         "foo.html"
     ).filename == str(Path(__file__).parent / "templates" / "foo.html")
+
+
+def test_url_for():
+    app = Sanic("templating-from-string")
+    app.extend()
+
+    template = r"url: {{ url_for('handler') }}"
+
+    @app.get("/one/two/three")
+    async def handler(_):
+        return await render(template_source=template)
+
+    _, response = app.test_client.get("/one/two/three")
+    assert response.text == "url: /one/two/three"


### PR DESCRIPTION
Added the `app.url_for` function for use in Jinja2 templates as requested in #87. 

Useful for referencing static files and endpoints in html templates. e.g.
- `{{ url_for('static', filename='styles.css') }}`
- `{{ url_for('dashboard') }}`

`url_for` is available within Jinja2 templates for Flask by default as part of the standard context (https://flask.palletsprojects.com/en/2.2.x/templating/). There may be other useful variables / functions to also add by default. e.g. `session` for logged in user details.