### PR TITLE
Allow dict schema definitions in body requests

### DIFF
--- a/sanic_ext/extensions/openapi/definitions.py
+++ b/sanic_ext/extensions/openapi/definitions.py
@@ -84,6 +84,9 @@ class MediaType(Definition):
 
     @staticmethod
     def make(value: Any):
+        if isinstance(value, dict):
+            if "schema" not in value:
+                return {"schema": value}
         return MediaType(Schema.make(value))
 
     @staticmethod

--- a/sanic_ext/extensions/openapi/definitions.py
+++ b/sanic_ext/extensions/openapi/definitions.py
@@ -85,8 +85,11 @@ class MediaType(Definition):
     @staticmethod
     def make(value: Any):
         if isinstance(value, dict):
-            if "schema" not in value:
-                return {"schema": value}
+            kwargs = {}
+            if "schema" in value:
+                kwargs = {**value}
+                value = kwargs.pop("schema")
+            return MediaType(value, **kwargs)
         return MediaType(Schema.make(value))
 
     @staticmethod

--- a/tests/extensions/openapi/test_decorators.py
+++ b/tests/extensions/openapi/test_decorators.py
@@ -405,9 +405,63 @@ def test_tag_decorator(app, decorator, tags):
     assert list(tagged) == list(tags)
 
 
-def test_definition_decorator_body_dict(app):
+def test_definition_decorator_body_dict_w_obj(app):
     @app.route("/")
     @openapi.definition(body={"application/json": Bar})
+    async def handler(_):
+        ...
+
+    body = get_path(app, "/")["requestBody"]
+    assert body == {
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                }
+            }
+        }
+    }
+
+
+def test_definition_decorator_body_dict_only_schema_head(app):
+    @app.route("/")
+    @openapi.definition(
+        body={
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                }
+            }
+        }
+    )
+    async def handler(_):
+        ...
+
+    body = get_path(app, "/")["requestBody"]
+    assert body == {
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                }
+            }
+        }
+    }
+
+
+def test_definition_decorator_body_dict_only_schema_root(app):
+    @app.route("/")
+    @openapi.definition(
+        body={
+            "application/json": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+            }
+        }
+    )
     async def handler(_):
         ...
 


### PR DESCRIPTION
Closes #125 

```python
from sanic import Sanic, json
from sanic_ext import validate, openapi
from pydantic import BaseModel, Field

class Test(BaseModel):
    foo: str = Field(description="Foo Description", example="FOOO")
    bar: str = "test"


app = Sanic("test")

@app.get("/")
@openapi.definition(
    body={'application/json': Test.schema()},
)
@validate(json=Test)
async def get(request):
    return json({})
```