### PR TITLE
Coerce param types for pydantic/attrs in validation

### DIFF
--- a/sanic_ext/extras/validation/clean.py
+++ b/sanic_ext/extras/validation/clean.py
@@ -1,0 +1,18 @@
+from typing import Any, Dict, Type, get_origin, get_type_hints
+
+from sanic_ext.utils.typing import is_generic
+
+
+def clean_data(model: Type[object], data: Dict[str, Any]) -> Dict[str, Any]:
+    hints = get_type_hints(model)
+    return {key: _coerce(hints[key], value) for key, value in data.items()}
+
+
+def _coerce(param_type, value: Any) -> Any:
+    if is_generic(param_type):
+        if get_origin(param_type) == list and not isinstance(value, list):
+            value = [value]
+    elif isinstance(value, list) and len(value) == 1:
+        value = value[0]
+
+    return value

--- a/sanic_ext/extras/validation/clean.py
+++ b/sanic_ext/extras/validation/clean.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict, Type, get_origin, get_type_hints
 
-from sanic_ext.utils.typing import is_generic
-
 
 def clean_data(model: Type[object], data: Dict[str, Any]) -> Dict[str, Any]:
     hints = get_type_hints(model)
@@ -9,10 +7,11 @@ def clean_data(model: Type[object], data: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _coerce(param_type, value: Any) -> Any:
-    if is_generic(param_type):
-        if get_origin(param_type) == list and not isinstance(value, list):
-            value = [value]
-    elif isinstance(value, list) and len(value) == 1:
+    if (
+        get_origin(param_type) != list
+        and isinstance(value, list)
+        and len(value) == 1
+    ):
         value = value[0]
 
     return value

--- a/sanic_ext/extras/validation/decorator.py
+++ b/sanic_ext/extras/validation/decorator.py
@@ -57,7 +57,7 @@ def validate(
                     kwargs=kwargs,
                     body_argument=body_argument,
                     allow_multiple=True,
-                    allow_coerce=False,
+                    allow_coerce=True,
                 )
             elif schemas["query"]:
                 await do_validation(

--- a/sanic_ext/extras/validation/setup.py
+++ b/sanic_ext/extras/validation/setup.py
@@ -56,7 +56,7 @@ def generate_schema(param):
 
 def _get_validator(model, schema, allow_multiple, allow_coerce):
     if is_pydantic(model):
-        return _validate_instance
+        return partial(_validate_instance, allow_coerce=allow_coerce)
 
     return partial(
         _validate_annotations,

--- a/sanic_ext/extras/validation/validators.py
+++ b/sanic_ext/extras/validation/validators.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, Tuple, Type
 from sanic_ext.exceptions import ValidationError
 
 from .check import check_data
+from .clean import clean_data
 
 try:
     from pydantic import ValidationError as PydanticValidationError
@@ -28,8 +29,9 @@ def validate_body(
         )
 
 
-def _validate_instance(model, body):
-    return model(**body)
+def _validate_instance(model, body, allow_coerce):
+    data = clean_data(model, body) if allow_coerce else body
+    return model(**data)
 
 
 def _validate_annotations(model, body, schema, allow_multiple, allow_coerce):

--- a/tests/extra/test_validation_attrs.py
+++ b/tests/extra/test_validation_attrs.py
@@ -1,0 +1,57 @@
+import attrs
+from sanic import json
+from sanic.views import HTTPMethodView
+
+from sanic_ext import validate
+
+
+def test_validate_decorator(app):
+    @attrs.define
+    class Pet:
+        name: str
+
+    @app.post("/function")
+    @validate(json=Pet)
+    async def handler(_, body: Pet):
+        return json({"is_pet": isinstance(body, Pet)})
+
+    class MethodView(HTTPMethodView, attach=app, uri="/method"):
+        decorators = [validate(json=Pet)]
+
+        async def post(self, _, body: Pet):
+            return json({"is_pet": isinstance(body, Pet)})
+
+    _, response = app.test_client.post("/function", json={"name": "Snoopy"})
+    assert response.status == 200
+    assert response.json["is_pet"]
+
+    _, response = app.test_client.post("/method", json={"name": "Snoopy"})
+    assert response.status == 200
+    assert response.json["is_pet"]
+
+
+def test_validate_query(app):
+    @attrs.define
+    class Search:
+        q: str
+
+    @app.get("/function")
+    @validate(query=Search)
+    async def handler(_, query: Search):
+        return json({"q": query.q, "is_search": isinstance(query, Search)})
+
+    class MethodView(HTTPMethodView, attach=app, uri="/method"):
+        decorators = [validate(query=Search)]
+
+        async def get(self, _, query: Search):
+            return json({"q": query.q, "is_search": isinstance(query, Search)})
+
+    _, response = app.test_client.get("/function", params={"q": "Snoopy"})
+    assert response.status == 200
+    assert response.json["is_search"]
+    assert response.json["q"] == "Snoopy"
+
+    _, response = app.test_client.get("/method", params={"q": "Snoopy"})
+    assert response.status == 200
+    assert response.json["is_search"]
+    assert response.json["q"] == "Snoopy"

--- a/tests/extra/test_validation_attrs.py
+++ b/tests/extra/test_validation_attrs.py
@@ -77,10 +77,12 @@ def test_validate_form(app):
     _, response = app.test_client.post("/function", data=SNOOPY_DATA)
     assert response.status == 200
     assert response.json["is_pet"]
+    assert response.json["pet"] == SNOOPY_DATA
 
     _, response = app.test_client.post("/method", data=SNOOPY_DATA)
     assert response.status == 200
     assert response.json["is_pet"]
+    assert response.json["pet"] == SNOOPY_DATA
 
 
 def test_validate_query(app):

--- a/tests/extra/test_validation_dataclass.py
+++ b/tests/extra/test_validation_dataclass.py
@@ -365,10 +365,12 @@ def test_validate_form(app):
     _, response = app.test_client.post("/function", data=SNOOPY_DATA)
     assert response.status == 200
     assert response.json["is_pet"]
+    assert response.json["pet"] == SNOOPY_DATA
 
     _, response = app.test_client.post("/method", data=SNOOPY_DATA)
     assert response.status == 200
     assert response.json["is_pet"]
+    assert response.json["pet"] == SNOOPY_DATA
 
 
 def test_validate_query(app):

--- a/tests/extra/test_validation_pydantic.py
+++ b/tests/extra/test_validation_pydantic.py
@@ -1,31 +1,84 @@
+from typing import List
+
 from pydantic.dataclasses import dataclass
 from sanic import json
 from sanic.views import HTTPMethodView
 
 from sanic_ext import validate
 
+SNOOPY_DATA = {"name": "Snoopy", "alter_ego": ["Flying Ace", "Joe Cool"]}
 
-def test_validate_decorator(app):
+
+def test_validate_json(app):
     @dataclass
     class Pet:
         name: str
+        alter_ego: List[str]
 
     @app.post("/function")
     @validate(json=Pet)
     async def handler(_, body: Pet):
-        return json({"is_pet": isinstance(body, Pet)})
+        return json(
+            {
+                "is_pet": isinstance(body, Pet),
+                "pet": {"name": body.name, "alter_ego": body.alter_ego},
+            }
+        )
 
     class MethodView(HTTPMethodView, attach=app, uri="/method"):
         decorators = [validate(json=Pet)]
 
         async def post(self, _, body: Pet):
-            return json({"is_pet": isinstance(body, Pet)})
+            return json(
+                {
+                    "is_pet": isinstance(body, Pet),
+                    "pet": {"name": body.name, "alter_ego": body.alter_ego},
+                }
+            )
 
-    _, response = app.test_client.post("/function", json={"name": "Snoopy"})
+    _, response = app.test_client.post("/function", json=SNOOPY_DATA)
+    assert response.status == 200
+    assert response.json["is_pet"]
+    assert response.json["pet"] == SNOOPY_DATA
+
+    _, response = app.test_client.post("/method", json=SNOOPY_DATA)
+    assert response.status == 200
+    assert response.json["is_pet"]
+    assert response.json["pet"] == SNOOPY_DATA
+
+
+def test_validate_form(app):
+    @dataclass
+    class Pet:
+        name: str
+        alter_ego: List[str]
+
+    @app.post("/function")
+    @validate(form=Pet)
+    async def handler(_, body: Pet):
+        return json(
+            {
+                "is_pet": isinstance(body, Pet),
+                "pet": {"name": body.name, "alter_ego": body.alter_ego},
+            }
+        )
+
+    class MethodView(HTTPMethodView, attach=app, uri="/method"):
+        decorators = [validate(form=Pet)]
+
+        async def post(self, _, body: Pet):
+            return json(
+                {
+                    "is_pet": isinstance(body, Pet),
+                    "pet": {"name": body.name, "alter_ego": body.alter_ego},
+                }
+            )
+
+    _, response = app.test_client.post("/function", data=SNOOPY_DATA)
     assert response.status == 200
     assert response.json["is_pet"]
 
-    _, response = app.test_client.post("/method", json={"name": "Snoopy"})
+    _, response = app.test_client.post("/method", data=SNOOPY_DATA)
     assert response.status == 200
     assert response.json["is_pet"]
 

--- a/tests/extra/test_validation_pydantic.py
+++ b/tests/extra/test_validation_pydantic.py
@@ -1,0 +1,57 @@
+from pydantic.dataclasses import dataclass
+from sanic import json
+from sanic.views import HTTPMethodView
+
+from sanic_ext import validate
+
+
+def test_validate_decorator(app):
+    @dataclass
+    class Pet:
+        name: str
+
+    @app.post("/function")
+    @validate(json=Pet)
+    async def handler(_, body: Pet):
+        return json({"is_pet": isinstance(body, Pet)})
+
+    class MethodView(HTTPMethodView, attach=app, uri="/method"):
+        decorators = [validate(json=Pet)]
+
+        async def post(self, _, body: Pet):
+            return json({"is_pet": isinstance(body, Pet)})
+
+    _, response = app.test_client.post("/function", json={"name": "Snoopy"})
+    assert response.status == 200
+    assert response.json["is_pet"]
+
+    _, response = app.test_client.post("/method", json={"name": "Snoopy"})
+    assert response.status == 200
+    assert response.json["is_pet"]
+
+
+def test_validate_query(app):
+    @dataclass
+    class Search:
+        q: str
+
+    @app.get("/function")
+    @validate(query=Search)
+    async def handler(_, query: Search):
+        return json({"q": query.q, "is_search": isinstance(query, Search)})
+
+    class MethodView(HTTPMethodView, attach=app, uri="/method"):
+        decorators = [validate(query=Search)]
+
+        async def get(self, _, query: Search):
+            return json({"q": query.q, "is_search": isinstance(query, Search)})
+
+    _, response = app.test_client.get("/function", params={"q": "Snoopy"})
+    assert response.status == 200
+    assert response.json["is_search"]
+    assert response.json["q"] == "Snoopy"
+
+    _, response = app.test_client.get("/method", params={"q": "Snoopy"})
+    assert response.status == 200
+    assert response.json["is_search"]
+    assert response.json["q"] == "Snoopy"

--- a/tests/extra/test_validation_pydantic.py
+++ b/tests/extra/test_validation_pydantic.py
@@ -77,10 +77,12 @@ def test_validate_form(app):
     _, response = app.test_client.post("/function", data=SNOOPY_DATA)
     assert response.status == 200
     assert response.json["is_pet"]
+    assert response.json["pet"] == SNOOPY_DATA
 
     _, response = app.test_client.post("/method", data=SNOOPY_DATA)
     assert response.status == 200
     assert response.json["is_pet"]
+    assert response.json["pet"] == SNOOPY_DATA
 
 
 def test_validate_query(app):

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ python =
 [testenv]
 deps =
     git+https://github.com/sanic-org/sanic.git#egg=sanic
+    pydantic
+    attrs
 ;     sanic21.6: sanic==21.6
 ;     sanic21.6: sanic_testing
 


### PR DESCRIPTION
Fixes #153
Fixes #147 

This will inspect the intended param type for query and form validation for pydantic and attrs and attempt to coerce from list to single item if that is what is expected, and leave it alone otherwise.