### PR TITLE
Hide static handlers by flag not name

### DIFF
--- a/sanic_ext/utils/route.py
+++ b/sanic_ext/utils/route.py
@@ -107,7 +107,7 @@ def get_all_routes(app, skip_prefix):
                 )
 
             for route in group:
-                if route.name and "static" in route.name:
+                if getattr(route.extra, "static", False):
                     continue
 
                 method_handlers = [


### PR DESCRIPTION
We have a better method for identifying static route definitions. Let's use that instead of the name which is modifiable.

Closes #155