### PR TITLE
Allow dict of annotations

### DIFF
--- a/sanic_ext/extensions/openapi/definitions.py
+++ b/sanic_ext/extensions/openapi/definitions.py
@@ -20,6 +20,8 @@ from typing import (
 
 from sanic.exceptions import SanicException
 
+from sanic_ext.utils.typing import contains_annotations
+
 from .types import Definition, Schema
 
 
@@ -79,7 +81,9 @@ class MediaType(Definition):
     schema: Schema
     example: Any
 
-    def __init__(self, schema: Schema, **kwargs):
+    def __init__(self, schema: Union[Schema, Dict[str, Any]], **kwargs):
+        if isinstance(schema, dict) and contains_annotations(schema):
+            schema = Schema.make(schema)
         super().__init__(schema=schema, **kwargs)
 
     @staticmethod

--- a/sanic_ext/extensions/openapi/types.py
+++ b/sanic_ext/extensions/openapi/types.py
@@ -320,9 +320,10 @@ def _properties(value: object) -> Dict:
         fields = {}
 
     cls = value if callable(value) else value.__class__
+    extra = value if isinstance(value, dict) else {}
     return {
         k: v
-        for k, v in {**get_type_hints(cls), **fields}.items()
+        for k, v in {**get_type_hints(cls), **fields, **extra}.items()
         if not k.startswith("_")
     }
 

--- a/sanic_ext/utils/typing.py
+++ b/sanic_ext/utils/typing.py
@@ -1,10 +1,11 @@
 import types
 import typing
+from inspect import isclass
 
 try:
     UnionType = types.UnionType  # type: ignore
 except AttributeError:
-    UnionType = type("UnionType", (), {})
+    UnionType = type("UnionType", (), {})  # type: ignore
 
 try:
     from pydantic import BaseModel
@@ -44,3 +45,24 @@ def is_pydantic(model):
 
 def is_attrs(model):
     return ATTRS and (hasattr(model, "__attrs_attrs__"))
+
+
+def flat_values(
+    item: typing.Union[
+        typing.Dict[str, typing.Any], typing.Iterable[typing.Any]
+    ]
+) -> typing.Set[typing.Any]:
+    values = set()
+    if isinstance(item, dict):
+        item = item.values()
+    for value in item:
+        if isinstance(value, dict) or isinstance(value, list):
+            values.update(flat_values(value))
+        else:
+            values.add(value)
+    return values
+
+
+def contains_annotations(d: typing.Dict[str, typing.Any]) -> bool:
+    values = flat_values(d)
+    return any(isclass(q) or is_generic(q) for q in values)

--- a/tests/extensions/injection/test_injection_registry.py
+++ b/tests/extensions/injection/test_injection_registry.py
@@ -103,6 +103,7 @@ async def test_finalize_allowed_types(raises, allowed):
         injections.finalize(Mock(), ConstantRegistry({}), allowed)
 
 
+@pytest.mark.asyncio
 async def test_constructor():
     injections = InjectionRegistry()
     injections.register(Foo, Foo.create)
@@ -118,6 +119,7 @@ async def test_constructor():
     foo.mock.assert_awaited_once_with(request, 999)
 
 
+@pytest.mark.asyncio
 async def test_constructor_nested():
     injections = InjectionRegistry()
     injections.register(Foo, Foo.create)
@@ -135,6 +137,7 @@ async def test_constructor_nested():
     bar.foo.mock.assert_awaited_once_with(request, 999)
 
 
+@pytest.mark.asyncio
 async def test_constructor_failure_kwargs():
     injections = InjectionRegistry()
     injections.register(Foo, Foo.create)
@@ -150,6 +153,7 @@ async def test_constructor_failure_kwargs():
         await constructor(request)
 
 
+@pytest.mark.asyncio
 async def test_constructor_failure_nested():
     injections = InjectionRegistry()
     injections.register(Foo, Foo.create)
@@ -166,6 +170,7 @@ async def test_constructor_failure_nested():
         await constructor(request)
 
 
+@pytest.mark.asyncio
 async def test_constructor_with_inherited_request():
     injections = InjectionRegistry()
     injections.register(Baz, Baz.create)

--- a/tests/extensions/openapi/test_decorators.py
+++ b/tests/extensions/openapi/test_decorators.py
@@ -453,6 +453,25 @@ def test_definition_decorator_body_dict_only_schema_head(app):
     }
 
 
+def test_definition_decorator_body_dict_types_schema_head(app):
+    @app.route("/")
+    @openapi.definition(body={"application/json": {"schema": {"name": str}}})
+    async def handler(_):
+        ...
+
+    body = get_path(app, "/")["requestBody"]
+    assert body == {
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                }
+            }
+        }
+    }
+
+
 def test_definition_decorator_body_dict_only_schema_root(app):
     @app.route("/")
     @openapi.definition(
@@ -465,6 +484,37 @@ def test_definition_decorator_body_dict_only_schema_root(app):
     )
     async def handler(_):
         ...
+
+    body = get_path(app, "/")["requestBody"]
+    assert body == {
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                }
+            }
+        }
+    }
+
+
+def test_definition_decorator_body_dict_types_schema_root(app):
+    @app.route("/")
+    @openapi.definition(body={"application/json": {"name": str}})
+    async def handler(_):
+        ...
+
+    body = get_path(app, "/")["requestBody"]
+    assert body == {
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                }
+            }
+        }
+    }
 
 
 def test_definition_decorator_httpmethodview(app):

--- a/tests/extensions/openapi/test_typing.py
+++ b/tests/extensions/openapi/test_typing.py
@@ -1,3 +1,4 @@
+import sys
 from typing import List, Optional
 
 import pytest
@@ -31,16 +32,17 @@ def test_dict_values_nested():
     assert values == {999, 888, 777, 666, None, True}
 
 
-@pytest.mark.parametrize(
-    "item,expected",
-    (
-        ({"foo": str}, True),
-        ({"foo": List[str]}, True),
-        ({"foo": list[str]}, True),
-        ({"foo": Optional[str]}, True),
-        ({"foo": Foo}, True),
-        ({"foo": "str"}, False),
-    ),
-)
+params = [
+    ({"foo": str}, True),
+    ({"foo": List[str]}, True),
+    ({"foo": Optional[str]}, True),
+    ({"foo": Foo}, True),
+    ({"foo": "str"}, False),
+]
+if sys.version_info >= (3, 9):
+    params.append(({"foo": list[str]}, True))
+
+
+@pytest.mark.parametrize("item,expected", params)
 def test_contains_annotations(item, expected):
     assert contains_annotations(item) == expected

--- a/tests/extensions/openapi/test_typing.py
+++ b/tests/extensions/openapi/test_typing.py
@@ -1,0 +1,46 @@
+from typing import List, Optional
+
+import pytest
+
+from sanic_ext.utils.typing import contains_annotations, flat_values
+
+
+class Foo:
+    ...
+
+
+def test_dict_values_nested():
+    values = flat_values(
+        {
+            "level1": {
+                "level2": {
+                    "level3": {
+                        "level4": {"item": 999, "items": [888, 777]},
+                        "item": 666,
+                    },
+                    "item": True,
+                },
+                "multiple": [
+                    {"nested": {"object": None}},
+                    {"nested": {"object": None}},
+                ],
+            },
+            "item": True,
+        }
+    )
+    assert values == {999, 888, 777, 666, None, True}
+
+
+@pytest.mark.parametrize(
+    "item,expected",
+    (
+        ({"foo": str}, True),
+        ({"foo": List[str]}, True),
+        ({"foo": list[str]}, True),
+        ({"foo": Optional[str]}, True),
+        ({"foo": Foo}, True),
+        ({"foo": "str"}, False),
+    ),
+)
+def test_contains_annotations(item, expected):
+    assert contains_annotations(item) == expected

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ python =
     3.10: py310
 
 [testenv]
+extras = test
 deps =
     git+https://github.com/sanic-org/sanic.git#egg=sanic
     pydantic
@@ -17,7 +18,6 @@ deps =
 ;     sanic21.6: sanic_testing
 
 commands =
-    pip install -e .['test']
     pytest {posargs:tests}
 
 


### PR DESCRIPTION
Closes #136

Fixes a side effect of #130 to allow for both:

```python
@openapi.definition(
    body={"application/json": Test.schema()},
)
```

```python
@openapi.definition(
    body={"application/json": {"test": str}}
)
```