### PR TITLE
Elegantly handle Pydantic model schema

### DIFF
--- a/sanic_ext/extensions/openapi/definitions.py
+++ b/sanic_ext/extensions/openapi/definitions.py
@@ -92,8 +92,12 @@ class MediaType(Definition):
                 kwargs = {**value}
                 value = kwargs.pop("schema")
             return MediaType(value, **kwargs)
-        elif isclass(value) and is_pydantic(value):
-            return MediaType(Component(value))
+        # See https://github.com/sanic-org/sanic-ext/issues/152
+        # The following lines will automatically inject pydantic models as
+        # components if that feature is desired. Until that decision is made
+        # this commented out code will remain.
+        # elif isclass(value) and is_pydantic(value):
+        #     return MediaType(Component(value))
         return MediaType(Schema.make(value))
 
     @staticmethod
@@ -128,7 +132,7 @@ class Response(Definition):
         )
 
     @staticmethod
-    def make(content, description: str = None, **kwargs):
+    def make(content, description: Optional[str] = None, **kwargs):
         if not description:
             description = "Default Response"
 
@@ -179,7 +183,7 @@ class ExternalDocumentation(Definition):
         super().__init__(url=url, description=description)
 
     @staticmethod
-    def make(url: str, description: str = None):
+    def make(url: str, description: Optional[str] = None):
         return ExternalDocumentation(url, description)
 
 
@@ -192,7 +196,7 @@ class Header(Definition):
         super().__init__(url=url, description=description)
 
     @staticmethod
-    def make(url: str, description: str = None):
+    def make(url: str, description: Optional[str] = None):
         return Header(url, description)
 
 
@@ -319,8 +323,7 @@ class SecurityScheme(Definition):
 
     @staticmethod
     def make(_type: str, cls: Type, **kwargs):
-        params = cls.__dict__ if hasattr(cls, "__dict__") else {}
-
+        params: Dict[str, Any] = getattr(cls, "__dict__", {})
         return SecurityScheme(_type, **params, **kwargs)
 
 
@@ -341,7 +344,10 @@ class Server(Definition):
     __nullable__ = None
 
     def __init__(
-        self, url: str, description: str = None, variables: dict = None
+        self,
+        url: str,
+        description: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(
             url=url, description=description, variables=variables or []

--- a/sanic_ext/extensions/openapi/openapi.py
+++ b/sanic_ext/extensions/openapi/openapi.py
@@ -27,6 +27,7 @@ from sanic_ext.extensions.openapi.builders import (
     OperationStore,
     SpecificationBuilder,
 )
+from sanic_ext.extensions.openapi.definitions import Component
 from sanic_ext.extensions.openapi.types import (
     Array,
     Binary,
@@ -67,6 +68,7 @@ __all__ = (
     "Binary",
     "Boolean",
     "Byte",
+    "Component",
     "Date",
     "DateTime",
     "Double",
@@ -140,7 +142,8 @@ def description(text: str) -> Callable[[T], T]:
 
 
 def document(
-    url: Union[str, definitions.ExternalDocumentation], description: str = None
+    url: Union[str, definitions.ExternalDocumentation],
+    description: Optional[str] = None,
 ) -> Callable[[T], T]:
     if isinstance(url, definitions.ExternalDocumentation):
         description = url.fields["description"]

--- a/sanic_ext/extensions/openapi/types.py
+++ b/sanic_ext/extensions/openapi/types.py
@@ -322,7 +322,7 @@ def _properties(value: object) -> Dict:
     cls = value if callable(value) else value.__class__
     return {
         k: v
-        for k, v in {**get_type_hints(cls), **fields}.items()
+        for k, v in {**fields, **get_type_hints(cls)}.items()
         if not k.startswith("_")
     }
 

--- a/tests/extensions/openapi/test_model_to_spec.py
+++ b/tests/extensions/openapi/test_model_to_spec.py
@@ -1,0 +1,97 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict
+
+import attrs
+import pytest
+from pydantic import BaseModel
+from pydantic.dataclasses import dataclass as pydataclass
+
+from sanic_ext import openapi
+
+from .utils import get_spec
+
+
+@dataclass
+class AlertDataclass:
+    hit: Dict[str, int]
+    last_updated: datetime
+
+
+@dataclass
+class AlertResponseDataclass:
+    alert: AlertDataclass
+    rule_id: str
+
+
+class AlertPydanticBaseModel(BaseModel):
+    hit: Dict[str, int]
+    last_updated: datetime
+
+
+class AlertResponsePydanticBaseModel(BaseModel):
+    alert: AlertPydanticBaseModel
+    rule_id: str
+
+
+@pydataclass
+class AlertPydanticDataclass:
+    hit: Dict[str, int]
+    last_updated: datetime
+
+
+@pydataclass
+class AlertResponsePydanticDataclass:
+    alert: AlertPydanticDataclass
+    rule_id: str
+
+
+@attrs.define
+class AlertAttrs:
+    hit: Dict[str, int]
+    last_updated: datetime
+
+
+@attrs.define
+class AlertResponseAttrs:
+    alert: AlertAttrs
+    rule_id: str
+
+
+@pytest.mark.parametrize(
+    "AlertResponse,check_alert",
+    (
+        (AlertResponseDataclass, False),
+        (AlertResponseAttrs, False),
+        (AlertResponsePydanticBaseModel, True),
+        (AlertResponsePydanticDataclass, True),
+    ),
+)
+def test_pydantic_base_model(app, AlertResponse, check_alert):
+    @app.get("/")
+    @openapi.definition(
+        body={"application/json": openapi.Component(AlertResponse)}
+    )
+    async def handler(_):
+        ...
+
+    spec = get_spec(app)
+    alert_response_name = AlertResponse.__name__
+    alert_name = "Alert" + alert_response_name[13:]
+
+    assert spec["paths"]["/"]["get"]["requestBody"] == {
+        "content": {
+            "application/json": {
+                "schema": {
+                    "$ref": f"#/components/schemas/{alert_response_name}"
+                }
+            }
+        }
+    }
+    assert alert_response_name in spec["components"]["schemas"]
+
+    if check_alert:
+        assert alert_name in spec["components"]["schemas"]
+        assert spec["components"]["schemas"][alert_response_name][
+            "properties"
+        ]["alert"] == {"$ref": f"#/components/schemas/{alert_name}"}


### PR DESCRIPTION
Closes #152

```python
class Alert(BaseModel):
    hit: dict[str, Any]
    last_updated: datetime


@pydataclass
class AlertResponse:
    alert: Alert
    rule_id: str
```

This will automatically drop all references and pydantic classes into components:

```json
{
  "openapi": "3.0.3",
  "info": {
    "title": "API",
    "version": "1.0.0",
    "contact": {}
  },
  "paths": {
    "/": {
      "get": {
        "operationId": "get~handler",
        "summary": "Handler",
        "requestBody": {
          "content": {
            "application/json": {
              "schema": {
                "$ref": "#/components/schemas/AlertResponse"
              }
            }
          }
        },
        "responses": {
          "default": {
            "description": "OK"
          }
        }
      }
    }
  },
  "tags": [],
  "servers": [],
  "security": [],
  "components": {
    "schemas": {
      "Alert": {
        "title": "Alert",
        "type": "object",
        "properties": {
          "hit": {
            "title": "Hit",
            "type": "object"
          },
          "last_updated": {
            "title": "Last Updated",
            "type": "string",
            "format": "date-time"
          }
        },
        "required": [
          "hit",
          "last_updated"
        ]
      },
      "AlertResponse": {
        "title": "AlertResponse",
        "type": "object",
        "properties": {
          "alert": {
            "$ref": "#/components/schemas/Alert"
          },
          "rule_id": {
            "title": "Rule Id",
            "type": "string"
          }
        },
        "required": [
          "alert",
          "rule_id"
        ]
      }
    }
  }
}
```