### PR TITLE
Use external address when SERVER_NAME is defined

### DIFF
--- a/sanic_ext/extensions/openapi/blueprint.py
+++ b/sanic_ext/extensions/openapi/blueprint.py
@@ -58,12 +58,14 @@ def blueprint_factory(config: Config):
             def index(
                 request: Request, page: str, html_title: str, custom_css: str
             ):
+                prefix = (
+                    request.app.url_for("openapi.index", _external=True)
+                    if getattr(request.app.config, "SERVER_NAME", None)
+                    else getattr(request.app.config, "OAS_URL_PREFIX")
+                )
                 return html(
                     page.replace("__VERSION__", version)
-                    .replace(
-                        "__URL_PREFIX__",
-                        request.app.url_for("openapi.index", _external=True),
-                    )
+                    .replace("__URL_PREFIX__", prefix)
                     .replace("__HTML_TITLE__", html_title)
                     .replace("__HTML_CUSTOM_CSS__", custom_css)
                 )

--- a/sanic_ext/extensions/openapi/blueprint.py
+++ b/sanic_ext/extensions/openapi/blueprint.py
@@ -38,17 +38,6 @@ def oauth2_handler(request: Request, version: str):
 
 
 def blueprint_factory(config: Config):
-    prefix = config.OAS_URL_PREFIX
-    if config.SERVER_NAME:
-        parsed = urlparse(
-            ""
-            if config.SERVER_NAME.startswith("http")
-            else "http://" + config.SERVER_NAME
-        )
-        if parsed.path:
-            prefix = "/" + join(
-                parsed.path.strip("/"), config.OAS_URL_PREFIX.strip("/")
-            )
     bp = Blueprint("openapi", url_prefix=config.OAS_URL_PREFIX)
 
     dir_path = dirname(realpath(__file__))
@@ -71,7 +60,10 @@ def blueprint_factory(config: Config):
             ):
                 return html(
                     page.replace("__VERSION__", version)
-                    .replace("__URL_PREFIX__", prefix)
+                    .replace(
+                        "__URL_PREFIX__",
+                        request.app.url_for("openapi.index", _external=True),
+                    )
                     .replace("__HTML_TITLE__", html_title)
                     .replace("__HTML_CUSTOM_CSS__", custom_css)
                 )

--- a/sanic_ext/extensions/openapi/blueprint.py
+++ b/sanic_ext/extensions/openapi/blueprint.py
@@ -1,7 +1,6 @@
 import inspect
 from functools import lru_cache, partial
-from os.path import abspath, dirname, join, realpath
-from urllib.parse import urlparse
+from os.path import abspath, dirname, realpath
 
 from sanic import Request
 from sanic.blueprints import Blueprint

--- a/sanic_ext/extensions/openapi/blueprint.py
+++ b/sanic_ext/extensions/openapi/blueprint.py
@@ -61,7 +61,7 @@ def blueprint_factory(config: Config):
                     request.app.url_for("openapi.index", _external=True)
                     if getattr(request.app.config, "SERVER_NAME", None)
                     else getattr(request.app.config, "OAS_URL_PREFIX")
-                )
+                ).rstrip("/")
                 return html(
                     page.replace("__VERSION__", version)
                     .replace("__URL_PREFIX__", prefix)


### PR DESCRIPTION
Closes #166 

When using `SERVER_NAME`, will use the docs external root as HTML prefix.

```python
app.config.SERVER_NAME = "localhost:8888/proxy"
```