### PR TITLE
Supporting custom logger in the background

### DIFF
--- a/sanic_ext/config.py
+++ b/sanic_ext/config.py
@@ -39,6 +39,7 @@ class Config(SanicConfig):
         injection_load_custom_constants: bool = False,
         logging: bool = False,
         logging_queue_max_size: int = 4096,
+        loggers: List[str] = ["sanic.access", "sanic.error", "sanic.root"],
         oas: bool = True,
         oas_autodoc: bool = True,
         oas_custom_file: Optional[os.PathLike] = None,
@@ -95,6 +96,7 @@ class Config(SanicConfig):
         self.INJECTION_LOAD_CUSTOM_CONSTANTS = injection_load_custom_constants
         self.LOGGING = logging
         self.LOGGING_QUEUE_MAX_SIZE = logging_queue_max_size
+        self.LOGGERS = loggers
         self.OAS = oas
         self.OAS_AUTODOC = oas_autodoc
         self.OAS_CUSTOM_FILE = oas_custom_file

--- a/sanic_ext/extensions/logging/logger.py
+++ b/sanic_ext/extensions/logging/logger.py
@@ -1,5 +1,5 @@
-from collections import defaultdict
 import logging
+from collections import defaultdict
 from logging import LogRecord
 from logging.handlers import QueueHandler
 from multiprocessing import Manager

--- a/sanic_ext/extensions/logging/logger.py
+++ b/sanic_ext/extensions/logging/logger.py
@@ -1,14 +1,14 @@
 from collections import defaultdict
+import logging
 from logging import LogRecord
 from logging.handlers import QueueHandler
 from multiprocessing import Manager
 from queue import Empty, Full
 from signal import SIGINT, SIGTERM
 from signal import signal as signal_func
+from typing import List
 
 from sanic import Sanic
-from sanic.log import access_logger, error_logger
-from sanic.log import logger as root_logger
 from sanic.log import server_logger
 
 
@@ -43,7 +43,8 @@ async def setup_server_logging(app: Sanic):
     app.ctx._logger_handlers = defaultdict(list)
     app.ctx._qhandler = qhandler
 
-    for logger_instance in (root_logger, access_logger, error_logger):
+    for logger_name in app.config.LOGGERS:
+        logger_instance = logging.getLogger(logger_name)
         for handler in logger_instance.handlers:
             logger_instance.removeHandler(handler)
         logger_instance.addHandler(qhandler)
@@ -57,11 +58,12 @@ async def remove_server_logging(app: Sanic):
 
 
 class Logger:
+    LOGGERS = []
+
     def __init__(self):
         self.run = True
         self.loggers = {
-            logger.name: logger
-            for logger in (root_logger, access_logger, error_logger)
+            logger: logging.getLogger(logger) for logger in self.LOGGERS
         }
 
     def __call__(self, queue) -> None:
@@ -81,12 +83,17 @@ class Logger:
             self.run = False
 
     @classmethod
+    def update_cls_loggers(cls, logger_names: List[str]):
+        cls.LOGGERS = logger_names
+
+    @classmethod
     def prepare(cls, app: Sanic):
         sync_manager = Manager()
         logger_queue = sync_manager.Queue(
             maxsize=app.config.LOGGING_QUEUE_MAX_SIZE
         )
         app.shared_ctx.logger_queue = logger_queue
+        cls.update_cls_loggers(app.config.LOGGERS)
 
     @classmethod
     def setup(cls, app: Sanic):

--- a/tests/extensions/logging/test_custom_background_logger.py
+++ b/tests/extensions/logging/test_custom_background_logger.py
@@ -1,20 +1,22 @@
 import pytest
-
 from sanic import Sanic
 from sanic.response import empty
+
 from sanic_ext.extensions.logging.logger import Logger
 
 
 def test_defult_config(app: Sanic):
-    assert hasattr(app.config, 'LOGGERS')
+    assert hasattr(app.config, "LOGGERS")
 
 
 def test_custom_background_logger(app: Sanic):
     assert Logger.LOGGERS == []
     Logger.prepare(app)
-    assert hasattr(app.shared_ctx, 'logger_queue')
+    assert hasattr(app.shared_ctx, "logger_queue")
     assert Logger.LOGGERS == app.config.LOGGERS
     assert "sanic.root" in Logger.LOGGERS
 
     logger = Logger()
-    assert len(logger.loggers) == len(Logger.LOGGERS) == len(app.config.LOGGERS)
+    assert (
+        len(logger.loggers) == len(Logger.LOGGERS) == len(app.config.LOGGERS)
+    )

--- a/tests/extensions/logging/test_custom_background_logger.py
+++ b/tests/extensions/logging/test_custom_background_logger.py
@@ -1,0 +1,20 @@
+import pytest
+
+from sanic import Sanic
+from sanic.response import empty
+from sanic_ext.extensions.logging.logger import Logger
+
+
+def test_defult_config(app: Sanic):
+    assert hasattr(app.config, 'LOGGERS')
+
+
+def test_custom_background_logger(app: Sanic):
+    assert Logger.LOGGERS == []
+    Logger.prepare(app)
+    assert hasattr(app.shared_ctx, 'logger_queue')
+    assert Logger.LOGGERS == app.config.LOGGERS
+    assert "sanic.root" in Logger.LOGGERS
+
+    logger = Logger()
+    assert len(logger.loggers) == len(Logger.LOGGERS) == len(app.config.LOGGERS)


### PR DESCRIPTION
Hi, the background logger is an excellent extension helping me log all my messages from a background process, with multiple processes.
But, it's not support to log any other logger backgrounding except `"sanic.access", "sanic.error", "sanic.root"`.

This PR is an attempt to support logging other custom loggers in the background.

to use:
```python
from sanic import Sanic

app = Sanic("MyApp")
app.config.LOGGING = True
app.config.LOGGERS = [
    "my_logger"
]
```

The default value of `app.config.LOGGERS = ["sanic.access", "sanic.error", "sanic.root"]`,
which is the same with `(root_logger, access_logger, error_logger)`
