### PR TITLE
Reduce healthcheck CPU

### DIFF
--- a/sanic_ext/extensions/health/monitor.py
+++ b/sanic_ext/extensions/health/monitor.py
@@ -120,7 +120,7 @@ class HealthMonitor:
         }
         while self.run:
             try:
-                name, timestamp = health_queue.get_nowait()
+                name, timestamp = health_queue.get(timeout=0.05)
             except Empty:
                 ...
             else:


### PR DESCRIPTION
Similar to #202 / #206- this reduces CPU util pretty drastically on my host- like 150% at "idle" down to 0-2%. Setup is M1 Mac running Sanic in Docker.