### PR TITLE
When appropriate use a __func__ handler

### DIFF
--- a/sanic_ext/extensions/openapi/blueprint.py
+++ b/sanic_ext/extensions/openapi/blueprint.py
@@ -152,7 +152,14 @@ def blueprint_factory(config: Config):
 
                 if hasattr(_handler, "view_class"):
                     _handler = getattr(_handler.view_class, method.lower())
-                operation = OperationStore()[_handler]
+                store = OperationStore()
+                if (
+                    _handler not in store
+                    and (func := getattr(_handler, "__func__", None))
+                    and func in store
+                ):
+                    _handler = func
+                operation = store[_handler]
 
                 if operation._exclude or "openapi" in operation.tags:
                     continue

--- a/tests/extensions/openapi/test_func_handler.py
+++ b/tests/extensions/openapi/test_func_handler.py
@@ -1,7 +1,7 @@
-from sanic_ext import openapi
-
 from sanic import Sanic
 from sanic.response import text
+
+from sanic_ext import openapi
 
 from .utils import get_spec
 

--- a/tests/extensions/openapi/test_func_handler.py
+++ b/tests/extensions/openapi/test_func_handler.py
@@ -1,0 +1,51 @@
+from sanic_ext import openapi
+
+from sanic import Sanic
+from sanic.response import text
+
+from .utils import get_spec
+
+
+def test_func_handlers(app: Sanic):
+    class TestClass:
+        @staticmethod
+        @openapi.definition(
+            summary="staticmethod custom summary",
+            tag="Test",
+        )
+        async def staticmethod_handler(request):
+            return text("...")
+
+        @classmethod
+        @openapi.definition(
+            summary="classmethod custom summary",
+            tag="Test",
+        )
+        async def classmethod_handler(cls, request):
+            return text("...")
+
+        @openapi.definition(
+            summary="instance method custom summary",
+            tag="Test",
+        )
+        async def instance_method_handler(self, request):
+            return text("...")
+
+    app.add_route(TestClass.staticmethod_handler, "/staticmethod")
+    app.add_route(TestClass.classmethod_handler, "/classmethod")
+    app.add_route(TestClass().instance_method_handler, "/instance_method")
+
+    spec = get_spec(app)
+    paths = spec["paths"]
+    assert len(paths) == 3
+    assert (
+        paths["/staticmethod"]["get"]["summary"]
+        == "staticmethod custom summary"
+    )
+    assert (
+        paths["/classmethod"]["get"]["summary"] == "classmethod custom summary"
+    )
+    assert (
+        paths["/instance_method"]["get"]["summary"]
+        == "instance method custom summary"
+    )


### PR DESCRIPTION
This comes from a discussion on the forums where classmethods and instance methods (not from a CBV) would not render as defined routes. This resulted because the bound methods were used as routes, and the definitions stores as functions. This PR will check if the handler does not exist, if there is a `__func__`, and if that `__func__` is defined. In that case, then it will use that as the defined handler and not recreate a default route definition.