### PR TITLE
Add support for more configuration variables in swagger docs

### DIFF
--- a/sanic_ext/extensions/openapi/blueprint.py
+++ b/sanic_ext/extensions/openapi/blueprint.py
@@ -62,9 +62,13 @@ def blueprint_factory(config: Config):
                     if getattr(request.app.config, "SERVER_NAME", None)
                     else getattr(request.app.config, "OAS_URL_PREFIX")
                 ).rstrip("/")
+                config_uri = getattr(request.app.config, "OAS_URI_TO_CONFIG")
+                config_json = getattr(request.app.config, "OAS_URI_TO_JSON")
                 return html(
                     page.replace("__VERSION__", version)
                     .replace("__URL_PREFIX__", prefix)
+                    .replace("__URL_CONFIG__", config_uri)
+                    .replace("__URL_JSON__", config_json)
                     .replace("__HTML_TITLE__", html_title)
                     .replace("__HTML_CUSTOM_CSS__", custom_css)
                 )

--- a/sanic_ext/extensions/openapi/ui/redoc.html
+++ b/sanic_ext/extensions/openapi/ui/redoc.html
@@ -14,7 +14,7 @@
         </style>
     </head>
     <body>
-        <redoc spec-url="__URL_PREFIX__/openapi.json"></redoc>
+        <redoc spec-url="__URL_PREFIX____URL_CONFIG__"></redoc>
         <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
     </body>
 </html>

--- a/sanic_ext/extensions/openapi/ui/swagger.html
+++ b/sanic_ext/extensions/openapi/ui/swagger.html
@@ -20,9 +20,9 @@
         <script>
             window.onload = function () {
                 const ui = SwaggerUIBundle({
-                    url: "__URL_PREFIX__/openapi.json",
+                    url: "__URL_PREFIX____URL_JSON__",
                     dom_id: "#openapi",
-                    configUrl: "__URL_PREFIX__/swagger-config",
+                    configUrl: "__URL_PREFIX____URL_CONFIG__",
                     deepLinking: true,
                     presets: [
                         SwaggerUIBundle.presets.apis,


### PR DESCRIPTION
When you configure `OAS_URI_TO_CONFIG` and `OAS_URI_TO_JSON` they don't flow down to the swagger docs properly, so this PR is to add support for that