### PR TITLE
Add msgspec support for openapi.Component and @validate()

### DIFF
--- a/sanic_ext/extensions/openapi/definitions.py
+++ b/sanic_ext/extensions/openapi/definitions.py
@@ -20,7 +20,7 @@ from typing import (
 
 from sanic.exceptions import SanicException
 
-from sanic_ext.utils.typing import contains_annotations, is_pydantic
+from sanic_ext.utils.typing import contains_annotations, is_pydantic, is_msgspec
 
 from .types import Definition, Schema
 
@@ -409,7 +409,14 @@ def Component(
     if not spec.has_component(field, name):
         prop_info = hints[field]
         type_ = prop_info.__args__[1]
-        if is_pydantic(obj):
+        if is_msgspec(obj):
+            import msgspec
+
+            _, definitions = msgspec.json.schema_components([obj], ref_template="#/components/schemas/{name}")
+            if definitions:
+                for key, value in definitions.items():
+                    spec.add_component(field, key, value)
+        elif is_pydantic(obj):
             try:
                 schema = obj.schema
             except AttributeError:
@@ -419,12 +426,12 @@ def Component(
             if definitions:
                 for key, value in definitions.items():
                     spec.add_component(field, key, value)
+            spec.add_component(field, name, component)
         else:
             component = (
                 type_.make(obj) if hasattr(type_, "make") else type_(obj)
             )
-
-        spec.add_component(field, name, component)
+            spec.add_component(field, name, component)
 
     return ref
 

--- a/sanic_ext/extensions/openapi/definitions.py
+++ b/sanic_ext/extensions/openapi/definitions.py
@@ -23,7 +23,7 @@ from sanic.exceptions import SanicException
 from sanic_ext.utils.typing import (
     contains_annotations,
     is_pydantic,
-    is_msgspec
+    is_msgspec,
 )
 
 from .types import Definition, Schema
@@ -417,8 +417,7 @@ def Component(
             import msgspec
 
             _, definitions = msgspec.json.schema_components(
-                [obj],
-                ref_template="#/components/schemas/{name}"
+                [obj], ref_template="#/components/schemas/{name}"
             )
             if definitions:
                 for key, value in definitions.items():

--- a/sanic_ext/extensions/openapi/definitions.py
+++ b/sanic_ext/extensions/openapi/definitions.py
@@ -22,8 +22,8 @@ from sanic.exceptions import SanicException
 
 from sanic_ext.utils.typing import (
     contains_annotations,
-    is_pydantic,
     is_msgspec,
+    is_pydantic,
 )
 
 from .types import Definition, Schema

--- a/sanic_ext/extensions/openapi/definitions.py
+++ b/sanic_ext/extensions/openapi/definitions.py
@@ -20,7 +20,11 @@ from typing import (
 
 from sanic.exceptions import SanicException
 
-from sanic_ext.utils.typing import contains_annotations, is_pydantic, is_msgspec
+from sanic_ext.utils.typing import (
+    contains_annotations,
+    is_pydantic,
+    is_msgspec
+)
 
 from .types import Definition, Schema
 
@@ -412,7 +416,10 @@ def Component(
         if is_msgspec(obj):
             import msgspec
 
-            _, definitions = msgspec.json.schema_components([obj], ref_template="#/components/schemas/{name}")
+            _, definitions = msgspec.json.schema_components(
+                [obj],
+                ref_template="#/components/schemas/{name}"
+            )
             if definitions:
                 for key, value in definitions.items():
                     spec.add_component(field, key, value)

--- a/sanic_ext/extras/validation/setup.py
+++ b/sanic_ext/extras/validation/setup.py
@@ -4,7 +4,7 @@ from inspect import isawaitable, isclass
 from sanic.log import logger
 
 from sanic_ext.exceptions import ValidationError
-from sanic_ext.utils.typing import is_pydantic
+from sanic_ext.utils.typing import is_msgspec, is_pydantic
 
 from .schema import make_schema
 from .validators import (
@@ -46,7 +46,7 @@ async def do_validation(
 
 def generate_schema(param):
     try:
-        if param is None or is_pydantic(param):
+        if param is None or is_msgspec(param) or is_pydantic(param):
             return param
     except TypeError:
         ...
@@ -55,7 +55,18 @@ def generate_schema(param):
 
 
 def _get_validator(model, schema, allow_multiple, allow_coerce):
-    if is_pydantic(model):
+    if is_msgspec(model):
+        import msgspec
+
+        def msgspec_validate_instance(*args, **kwargs):
+            try:
+                kwargs['allow_coerce'] = allow_coerce
+                return _validate_instance(*args, **kwargs)
+            except msgspec.ValidationError as e:
+                # Convert msgspec.ValidationError into TypeError for consistent behaviour with pydantic, attrs, etc..
+                raise TypeError(str(e))
+        return msgspec_validate_instance
+    elif is_pydantic(model):
         return partial(_validate_instance, allow_coerce=allow_coerce)
 
     return partial(

--- a/sanic_ext/extras/validation/setup.py
+++ b/sanic_ext/extras/validation/setup.py
@@ -60,12 +60,13 @@ def _get_validator(model, schema, allow_multiple, allow_coerce):
 
         def msgspec_validate_instance(*args, **kwargs):
             try:
-                kwargs['allow_coerce'] = allow_coerce
+                kwargs["allow_coerce"] = allow_coerce
                 return _validate_instance(*args, **kwargs)
             except msgspec.ValidationError as e:
                 # Convert msgspec.ValidationError into TypeError for consistent
                 # behaviour with pydantic, attrs, etc..
                 raise TypeError(str(e))
+
         return msgspec_validate_instance
     elif is_pydantic(model):
         return partial(_validate_instance, allow_coerce=allow_coerce)

--- a/sanic_ext/extras/validation/setup.py
+++ b/sanic_ext/extras/validation/setup.py
@@ -8,9 +8,9 @@ from sanic_ext.utils.typing import is_msgspec, is_pydantic
 
 from .schema import make_schema
 from .validators import (
+    _msgspec_validate_instance,
     _validate_annotations,
     _validate_instance,
-    _msgspec_validate_instance,
     validate_body,
 )
 

--- a/sanic_ext/extras/validation/setup.py
+++ b/sanic_ext/extras/validation/setup.py
@@ -63,7 +63,8 @@ def _get_validator(model, schema, allow_multiple, allow_coerce):
                 kwargs['allow_coerce'] = allow_coerce
                 return _validate_instance(*args, **kwargs)
             except msgspec.ValidationError as e:
-                # Convert msgspec.ValidationError into TypeError for consistent behaviour with pydantic, attrs, etc..
+                # Convert msgspec.ValidationError into TypeError for consistent
+                # behaviour with pydantic, attrs, etc..
                 raise TypeError(str(e))
         return msgspec_validate_instance
     elif is_pydantic(model):

--- a/sanic_ext/extras/validation/setup.py
+++ b/sanic_ext/extras/validation/setup.py
@@ -10,6 +10,7 @@ from .schema import make_schema
 from .validators import (
     _validate_annotations,
     _validate_instance,
+    _msgspec_validate_instance,
     validate_body,
 )
 
@@ -56,18 +57,7 @@ def generate_schema(param):
 
 def _get_validator(model, schema, allow_multiple, allow_coerce):
     if is_msgspec(model):
-        import msgspec
-
-        def msgspec_validate_instance(*args, **kwargs):
-            try:
-                kwargs["allow_coerce"] = allow_coerce
-                return _validate_instance(*args, **kwargs)
-            except msgspec.ValidationError as e:
-                # Convert msgspec.ValidationError into TypeError for consistent
-                # behaviour with pydantic, attrs, etc..
-                raise TypeError(str(e))
-
-        return msgspec_validate_instance
+        return partial(_msgspec_validate_instance, allow_coerce=allow_coerce)
     elif is_pydantic(model):
         return partial(_validate_instance, allow_coerce=allow_coerce)
 

--- a/sanic_ext/extras/validation/validators.py
+++ b/sanic_ext/extras/validation/validators.py
@@ -30,6 +30,18 @@ def validate_body(
         )
 
 
+def _msgspec_validate_instance(model, body, allow_coerce):
+    import msgspec
+
+    try:
+        data = clean_data(model, body) if allow_coerce else body
+        return msgspec.convert(data, model)
+    except msgspec.ValidationError as e:
+        # Convert msgspec.ValidationError into TypeError for consistent
+        # behaviour with _validate_instance
+        raise TypeError(str(e))
+
+
 def _validate_instance(model, body, allow_coerce):
     data = clean_data(model, body) if allow_coerce else body
     return model(**data)

--- a/tests/extensions/openapi/test_model_spec.py
+++ b/tests/extensions/openapi/test_model_spec.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 import attrs
 import pytest
+from msgspec import Struct
 from pydantic import BaseModel
 from pydantic.dataclasses import dataclass as pydataclass
 
@@ -31,6 +32,16 @@ class AlertPydanticBaseModel(BaseModel):
 
 class AlertResponsePydanticBaseModel(BaseModel):
     alert: AlertPydanticBaseModel
+    rule_id: str
+
+
+class AlertMsgspecBaseModel(Struct):
+    hit: Dict[str, int]
+    last_updated: datetime
+
+
+class AlertResponseMsgspecBaseModel(Struct):
+    alert: AlertMsgspecBaseModel
     rule_id: str
 
 
@@ -63,6 +74,7 @@ class AlertResponseAttrs:
     (
         (AlertResponseDataclass, False),
         (AlertResponseAttrs, False),
+        (AlertResponseMsgspecBaseModel, True),
         (AlertResponsePydanticBaseModel, True),
         (AlertResponsePydanticDataclass, True),
     ),

--- a/tests/extra/test_validation.py
+++ b/tests/extra/test_validation.py
@@ -13,6 +13,7 @@ def _dataclass_spec(annotation):
     @dataclass
     class Spec:
         name: annotation
+
     return Spec
 
 
@@ -22,6 +23,7 @@ def _attrs_spec(annotation):
     @attrs.define
     class Spec:
         name: annotation
+
     return Spec
 
 
@@ -30,6 +32,7 @@ def _msgspec_spec(annotation):
 
     class Spec(Struct):
         name: annotation
+
     return Spec
 
 
@@ -39,6 +42,7 @@ def _pydantic_spec(annotation):
     @pydataclass
     class Spec:
         name: annotation
+
     return Spec
 
 


### PR DESCRIPTION
Add support for using [msgspec](https://jcristharif.com/msgspec/index.html) in `openapi.Component` and with validation -- `@validate()`

I also parameterized the tests in `test_validation` to verify that `msgspec` worked, but I also added the equivalent `attrs` and `pydantic` tests as well to make sure that all cases were covered.

If I wasn't sure about compatibility, I used inline imports -- as opposed to top-of-file imports -- for `msgspec`.