### PR TITLE
chore: strip CORS_ORIGINS before assigning value

### DIFF
--- a/sanic_ext/extensions/http/cors.py
+++ b/sanic_ext/extensions/http/cors.py
@@ -308,7 +308,7 @@ def _parse_allow_origins(
         if value == "*":
             origins = [WILDCARD_PATTERN]
         else:
-            origins = value.split(",")
+            origins = [origin.strip() for origin in value.split(",")]
     elif isinstance(value, re.Pattern):
         origins = [value]
     elif isinstance(value, list):


### PR DESCRIPTION
In case the CORS_ORIGINS value is a comma separated string but with spaces in between them like
`https://google.com, http://localhost:3000`. In this case only the first URL is whitelisted. Stripping the spaces fixes the issue.

My team spent half of the day debugging this :)