### PR TITLE
fix: Updated pydantic schema method to model_json_schema

### DIFF
--- a/sanic_ext/extensions/openapi/definitions.py
+++ b/sanic_ext/extensions/openapi/definitions.py
@@ -424,9 +424,9 @@ def Component(
                     spec.add_component(field, key, value)
         elif is_pydantic(obj):
             try:
-                schema = obj.schema
+                schema = obj.model_json_schema
             except AttributeError:
-                schema = obj.__pydantic_model__.schema
+                schema = obj.__pydantic_model__.model_json_schema
             component = schema(ref_template="#/components/schemas/{model}")
             definitions = component.pop("definitions", None)
             if definitions:


### PR DESCRIPTION
The `schema` method is deprecated; use `model_json_schema` instead. Deprecated in Pydantic V2.0 to be removed in V3.0.