### PR TITLE
Remove requirement on old version of setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<60.0", "wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]


### PR DESCRIPTION
The pyproject file specified a requirement on an old version of setuptools. This pull request removes that requirement so that the latest version of setuptools can be used.

I mainly did this to simplify packaging this project in NixOS.