### PR TITLE
fix: properly handle ignore/forbid for extra query params in pydantic validation

### DIFF
--- a/sanic_ext/extras/validation/clean.py
+++ b/sanic_ext/extras/validation/clean.py
@@ -3,7 +3,9 @@ from typing import Any, Dict, Type, get_origin, get_type_hints
 
 def clean_data(model: Type[object], data: Dict[str, Any]) -> Dict[str, Any]:
     hints = get_type_hints(model)
-    return {key: _coerce(hints[key], value) for key, value in data.items()}
+    return {
+        key: _coerce(hints.get(key, Any), value) for key, value in data.items()
+    }
 
 
 def _coerce(param_type, value: Any) -> Any:

--- a/tests/extra/test_validation_pydantic.py
+++ b/tests/extra/test_validation_pydantic.py
@@ -88,7 +88,7 @@ def test_validate_form(app):
 
 
 def test_validate_query(app):
-    @dataclass
+    @dataclass()
     class Search:
         q: str
 
@@ -112,6 +112,66 @@ def test_validate_query(app):
     assert response.status == 200
     assert response.json["is_search"]
     assert response.json["q"] == "Snoopy"
+
+
+def test_validate_query_basemodel_ignore_extra(app):
+    class Search(pydantic.BaseModel):
+        model_config = pydantic.ConfigDict(extra="ignore")
+        q: str
+
+    @app.get("/function")
+    @validate(query=Search)
+    async def handler(_, query: Search):
+        return json({"q": query.q, "is_search": isinstance(query, Search)})
+
+    class MethodView(HTTPMethodView, attach=app, uri="/method"):
+        decorators = [validate(query=Search)]
+
+        async def get(self, _, query: Search):
+            return json({"q": query.q, "is_search": isinstance(query, Search)})
+
+    _, response = app.test_client.get(
+        "/function", params={"q": "Snoopy", "extra_param": "extra value"}
+    )
+    assert response.status == 200
+    assert response.json["is_search"]
+    assert response.json["q"] == "Snoopy"
+
+    _, response = app.test_client.get(
+        "/method", params={"q": "Snoopy", "extra_param": "extra value"}
+    )
+    assert response.status == 200
+    assert response.json["is_search"]
+    assert response.json["q"] == "Snoopy"
+
+
+def test_validate_query_basemodel_forbid_extra(app):
+    class Search(pydantic.BaseModel):
+        model_config = pydantic.ConfigDict(extra="forbid")
+        q: str
+
+    @app.get("/function")
+    @validate(query=Search)
+    async def handler(_, query: Search):
+        return json({"q": query.q, "is_search": isinstance(query, Search)})
+
+    class MethodView(HTTPMethodView, attach=app, uri="/method"):
+        decorators = [validate(query=Search)]
+
+        async def get(self, _, query: Search):
+            return json({"q": query.q, "is_search": isinstance(query, Search)})
+
+    _, response = app.test_client.get(
+        "/function", params={"q": "Snoopy", "extra_param": "extra value"}
+    )
+    assert response.status == 400
+    assert "Extra inputs are not permitted" in response.json["message"]
+
+    _, response = app.test_client.get(
+        "/method", params={"q": "Snoopy", "extra_param": "extra value"}
+    )
+    assert response.status == 400
+    assert "Extra inputs are not permitted" in response.text
 
 
 class User(pydantic.BaseModel):


### PR DESCRIPTION
fixes #247 