### PR TITLE
Fix pydantic type detection

### DIFF
--- a/sanic_ext/utils/typing.py
+++ b/sanic_ext/utils/typing.py
@@ -47,9 +47,12 @@ def is_optional(item):
 
 
 def is_pydantic(model):
-    return PYDANTIC and (
-        issubclass(model, BaseModel) or hasattr(model, "__pydantic_model__")
-    )
+    try:
+        return PYDANTIC and (
+            issubclass(model, BaseModel) or hasattr(model, "__pydantic_model__")
+        )
+    except TypeError:
+        return False
 
 
 def is_attrs(model):


### PR DESCRIPTION
`is_pydantic` crashes when it is supplied with something that isn't a class. This prevents me from doing this:

<details>
<summary>Expand code sample</summary>

```
from sanic import Sanic
from sanic.response import json
from sanic_ext import openapi

app = Sanic("testapp")


openapi.component({"type": "string"}, name="TestResponse")


@app.get("/")
@openapi.response(
    200, {"application/json": {"schema": {"$ref": "#/components/schemas/TestResponse"}}}
)
def index(req):
    return json("Hello")


if __name__ == "__main__":
    app.run(debug=True, dev=True, port=1234)
```

</details>

The `openapi.component({"type": "string"}, name="TestResponse")` would properly add the schema if it weren't for the check whether the passed content is a pydantic type. Here is the stack trace of the error:

```
Traceback (most recent call last):
  File ".../test.py", line 8, in <module>
    openapi.component({"type": "string"}, name="TestResponse")
  File ".../python3.12/site-packages/sanic_ext/extensions/openapi/openapi.py", line 363, in component
    definitions.Component(model, **params)
  File ".../python3.12/site-packages/sanic_ext/extensions/openapi/definitions.py", line 425, in Component
    elif is_pydantic(obj):
         ^^^^^^^^^^^^^^^^
  File ".../python3.12/site-packages/sanic_ext/utils/typing.py", line 51, in is_pydantic
    issubclass(model, BaseModel) or hasattr(model, "__pydantic_model__")
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen abc>", line 123, in __subclasscheck__
TypeError: issubclass() arg 1 must be a class
```

It works fine after the proposed change. I would appreciate a merge :)