### PR TITLE
FIx handler list mutation while removing handlers

### DIFF
--- a/sanic_ext/extensions/logging/logger.py
+++ b/sanic_ext/extensions/logging/logger.py
@@ -46,8 +46,8 @@ async def setup_server_logging(app: Sanic):
 
     for logger_name in app.config.LOGGERS:
         logger_instance = logging.getLogger(logger_name)
-        for handler in logger_instance.handlers:
-            logger_instance.removeHandler(handler)
+        # clear handlers
+        logger_instance.handlers.clear()
         logger_instance.addHandler(qhandler)
 
 

--- a/sanic_ext/extensions/logging/logger.py
+++ b/sanic_ext/extensions/logging/logger.py
@@ -46,7 +46,6 @@ async def setup_server_logging(app: Sanic):
 
     for logger_name in app.config.LOGGERS:
         logger_instance = logging.getLogger(logger_name)
-        # clear handlers
         logger_instance.handlers.clear()
         logger_instance.addHandler(qhandler)
 


### PR DESCRIPTION
Fixes #254 : "Removing handlers in Background Logger extension removes only one handler."

Issue only occurs when there are more than one handler to remove from the list of handlers. Please refer to comments here #254 