### PR TITLE
Exclude tests from wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,10 @@ packages = find:
 install_requires =
     pyyaml>=3.0.0
 
+[options.packages.find]
+exclude =
+    tests*
+
 [options.package_data]
 sanic_ext =
     py.typed


### PR DESCRIPTION
Congratulations on 24.12.0! :tada:

As part of some build plumbing on [conda-forge](https://github.com/conda-forge/sanic-ext-feedstock/pull/4), I noted that installing from the sdist ended up with extra files in `site-packages`. 

This PR adds configuration to avoid copying the `tests` module to `site-packages/tests`. I locally verified it will continue shipping the tests in the `sdist` with this change, which we do execute downstream.