### PR TITLE
Fixes KeyErrors in query param validation (Issues #247 and #250)

### DIFF
--- a/sanic_ext/extras/validation/clean.py
+++ b/sanic_ext/extras/validation/clean.py
@@ -1,12 +1,34 @@
-from typing import Any, get_origin, get_type_hints
+from typing import Any, Optional, Type, get_origin, get_type_hints
+
+import pydantic
 
 
-def clean_data(model: type[object], data: dict[str, Any]) -> dict[str, Any]:
-    hints = get_type_hints(model)
-    return {key: _coerce(hints[key], value) for key, value in data.items()}
+def clean_data(
+    model: type[object],
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    if isinstance(model, pydantic.BaseModel):
+        hints: dict[str, type] = {}
+        for key, field in model.__annotations__.items():
+            hints[key] = field.annotation
+            if alias := (
+                getattr(field, "validation_alias", None)
+                or getattr(field, "alias", None)
+            ):
+                hints[alias] = field.annotation
+        hints = {
+            key: field.annotation
+            for key, field in model.__annotations__.items()
+        }
+    else:
+        hints = get_type_hints(model)
+    return {
+        key: _coerce(hints.get(key, None), value)
+        for key, value in data.items()
+    }
 
 
-def _coerce(param_type, value: Any) -> Any:
+def _coerce(param_type: Optional[Type], value: Any) -> Any:
     if (
         get_origin(param_type) is not list
         and isinstance(value, list)


### PR DESCRIPTION
Fixes KeyError when passing extra query params ([Issue #247](https://github.com/sanic-org/sanic-ext/issues/247))
Fixes KeyError when validating Pydantic models that have aliased fields ([Issue #250](https://github.com/sanic-org/sanic-ext/issues/250)) 

