### PR TITLE
feat(openapi): Support stoplight elements as openapi UI

### DIFF
--- a/sanic_ext/config.py
+++ b/sanic_ext/config.py
@@ -59,6 +59,7 @@ class Config(SanicConfig):
         oas_ignore_options: bool = True,
         oas_path_to_redoc_html: Optional[str] = None,
         oas_path_to_swagger_html: Optional[str] = None,
+        oas_path_to_elements_html: Optional[str] = None,
         oas_ui_default: Optional[str] = "redoc",
         oas_ui_redoc: bool = True,
         oas_ui_redoc_html_title: str = "ReDoc",
@@ -68,10 +69,14 @@ class Config(SanicConfig):
         oas_ui_swagger_custom_css: str = "",
         oas_ui_swagger_version: str = "4.10.3",
         oas_ui_swagger_oauth2_redirect: str = "/oauth2-redirect.html",
+        oas_ui_elements:bool = True,
+        oas_ui_elements_html_title: str = "Stoplight Elements",
+        oas_ui_elements_custom_css: str = "",
         oas_uri_to_config: str = "/swagger-config",
         oas_uri_to_json: str = "/openapi.json",
         oas_uri_to_redoc: str = "/redoc",
         oas_uri_to_swagger: str = "/swagger",
+        oas_uri_to_elements: str = "/elements",
         oas_url_prefix: str = "/docs",
         swagger_ui_configuration: Optional[dict[str, Any]] = None,
         templating_path_to_templates: Union[
@@ -117,6 +122,7 @@ class Config(SanicConfig):
         self.OAS_IGNORE_OPTIONS = oas_ignore_options
         self.OAS_PATH_TO_REDOC_HTML = oas_path_to_redoc_html
         self.OAS_PATH_TO_SWAGGER_HTML = oas_path_to_swagger_html
+        self.OAS_PATH_TO_ELEMENTS_HTML = oas_path_to_elements_html
         self.OAS_UI_DEFAULT = oas_ui_default
         self.OAS_UI_REDOC = oas_ui_redoc
         self.OAS_UI_REDOC_HTML_TITLE = oas_ui_redoc_html_title
@@ -126,10 +132,14 @@ class Config(SanicConfig):
         self.OAS_UI_SWAGGER_CUSTOM_CSS = oas_ui_swagger_custom_css
         self.OAS_UI_SWAGGER_VERSION = oas_ui_swagger_version
         self.OAS_UI_SWAGGER_OAUTH2_REDIRECT = oas_ui_swagger_oauth2_redirect
+        self.OAS_UI_ELEMENTS = oas_ui_elements
+        self.OAS_UI_ELEMENTS_HTML_TITLE = oas_ui_elements_html_title
+        self.OAS_UI_ELEMENTS_CUSTOM_CSS = oas_ui_elements_custom_css
         self.OAS_URI_TO_CONFIG = oas_uri_to_config
         self.OAS_URI_TO_JSON = oas_uri_to_json
         self.OAS_URI_TO_REDOC = oas_uri_to_redoc
         self.OAS_URI_TO_SWAGGER = oas_uri_to_swagger
+        self.OAS_URI_TO_ELEMENTS = oas_uri_to_elements
         self.OAS_URL_PREFIX = oas_url_prefix
         self.SWAGGER_UI_CONFIGURATION = swagger_ui_configuration or {
             "apisSorter": "alpha",

--- a/sanic_ext/extensions/openapi/blueprint.py
+++ b/sanic_ext/extensions/openapi/blueprint.py
@@ -44,7 +44,7 @@ def blueprint_factory(config: Config):
     dir_path = dirname(realpath(__file__))
     dir_path = abspath(dir_path + "/ui")
 
-    for ui in ("redoc", "swagger"):
+    for ui in ("redoc", "swagger", "elements"):
         if getattr(config, f"OAS_UI_{ui}".upper()):
             path = getattr(config, f"OAS_PATH_TO_{ui}_HTML".upper())
             uri = getattr(config, f"OAS_URI_TO_{ui}".upper())

--- a/sanic_ext/extensions/openapi/ui/elements.html
+++ b/sanic_ext/extensions/openapi/ui/elements.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Elements in HTML</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/@stoplight/elements/web-components.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@stoplight/elements/styles.min.css">
+</head>
+<body>
+
+<elements-api id="docs" router="hash" layout="sidebar" apiDescriptionUrl="__URL_PREFIX__/openapi.json"/>
+
+</body>
+</html>
+


### PR DESCRIPTION
## Relates to Issue
This PR implements the feature request in #272, introducing Stoplight Elements as an alternative OpenAPI UI. It addresses the limitations of Redoc/Swagger UI (e.g., lack of auto-generated code samples, poor link sharing) while retaining full compatibility with Sanic Ext’s existing OpenAPI workflow.

## What are the benefits
- Auto-generates request code for multiple platforms (e.g., curl, JS, Python, Go, Node.js)
- Supports interactive API testing in the UI
- Cleaner and more modern user interface

## What Changed
- Add `elements.html` in `openapi/ui` dir
- Modify `blueprint.py`, add elements in ui tuple.
- Add more openapi args in `config.py`

## How to Test

This is a simple test:

```python
from dataclasses import dataclass

from sanic import Sanic, response

from sanic_ext import openapi, Extend

app = Sanic("MyHelloWorldApp")
app.config.update_config({"OAS_UI_DEFAULT": 'elements'})
Extend(app)


@dataclass
class Foo:
    schemas: str = 'foo'


openapi.Component(Foo, name='foo-uuid')


@app.post("/")
@openapi.definition(
    body={'application/json': {'$ref': '#/components/schemas/foo-uuid'}},
)
def foo(request):
    return response.empty()


if __name__ == '__main__':
    app.run(host="0.0.0.0", port=8000)

```

Open browse and access [`/docs`](http://localhost:8000/docs) or [`/docs/elements`](http://localhost:8000/docs/elements), the effect is as shown below:

<img width="1920" height="967" alt="image" src="https://github.com/user-attachments/assets/b08501fe-8e76-4884-aea3-f4c922233a04" />

## Other Potential Issues

When parsing the OpenAPI schema, Stoplight Elements expects operationId values to contain only ASCII characters.
If the operationId includes non-ASCII characters (such as Chinese, Japanese, or Korean), endpoint links in the UI may fail to resolve or navigate correctly.

>🔍 This can happen if operationId is auto-generated from function names or descriptions containing non-English characters.

**Please clearly document this issue in the sanic-guide.**

Temporary workaround:

```python
@app.post("/")
@openapi.definition(
    operation="foo", # Explicitly define the OpenAPI operation
    body={'application/json': {'$ref': '#/components/schemas/foo-uuid'}},
)
def foo(request):
    return response.empty()
```

Recommendation:
• Ensure all operationId values contain only ASCII characters (e.g., English letters, numbers, underscores).
• Alternatively, consider updating the auto-generation logic in sanic-ext to enforce this constraint programmatically.
