### PR TITLE
Updated redoc.standalone.js URL

### DIFF
--- a/sanic_ext/extensions/openapi/ui/redoc.html
+++ b/sanic_ext/extensions/openapi/ui/redoc.html
@@ -15,6 +15,6 @@
     </head>
     <body>
         <redoc spec-url="__URL_PREFIX__/openapi.json"></redoc>
-        <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+        <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
     </body>
 </html>


### PR DESCRIPTION
It seems the URL at `https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js` is gone.

So according to [Redoc Github](https://github.com/Redocly/redoc#add-an-html-element-to-the-page) I updated the link to `https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js`