### PR TITLE
Always use lax mode when using msgspec to validate query params/forms

### DIFF
--- a/sanic_ext/extras/validation/decorator.py
+++ b/sanic_ext/extras/validation/decorator.py
@@ -20,7 +20,6 @@ def validate(
     body_argument: str = "body",
     query_argument: str = "query",
     body_strict: bool = True,
-    query_strict: bool = True,
 ) -> Callable[[T], T]:
     schemas = {
         key: generate_schema(param)
@@ -61,7 +60,7 @@ def validate(
                     body_argument=body_argument,
                     allow_multiple=True,
                     allow_coerce=True,
-                    strict=body_strict,
+                    strict=False,
                 )
             if schemas["query"]:
                 await do_validation(
@@ -73,7 +72,7 @@ def validate(
                     body_argument=query_argument,
                     allow_multiple=True,
                     allow_coerce=True,
-                    strict=query_strict,
+                    strict=False,
                 )
             retval = f(*args, **kwargs)
             if isawaitable(retval):

--- a/sanic_ext/extras/validation/decorator.py
+++ b/sanic_ext/extras/validation/decorator.py
@@ -19,7 +19,7 @@ def validate(
     query: Optional[Union[Callable[[Request], bool], type[object]]] = None,
     body_argument: str = "body",
     query_argument: str = "query",
-    body_strict: bool = True,
+    strict: bool | None = None,
 ) -> Callable[[T], T]:
     schemas = {
         key: generate_schema(param)
@@ -48,7 +48,7 @@ def validate(
                     body_argument=body_argument,
                     allow_multiple=False,
                     allow_coerce=False,
-                    strict=body_strict,
+                    strict=strict,
                 )
             elif schemas["form"]:
                 await do_validation(

--- a/sanic_ext/extras/validation/setup.py
+++ b/sanic_ext/extras/validation/setup.py
@@ -64,7 +64,9 @@ def _get_validator(model, schema, allow_multiple, allow_coerce, strict=True):
             strict=strict,
         )
     elif is_pydantic(model):
-        return partial(_validate_instance, allow_coerce=allow_coerce)
+        return partial(
+            _validate_instance, allow_coerce=allow_coerce, strict=strict
+        )
 
     return partial(
         _validate_annotations,

--- a/sanic_ext/extras/validation/validators.py
+++ b/sanic_ext/extras/validation/validators.py
@@ -31,7 +31,7 @@ def validate_body(
         ) from None
 
 
-def _msgspec_validate_instance(model, body, allow_coerce, strict=True):
+def _msgspec_validate_instance(model, body, allow_coerce, strict=None):
     import msgspec
 
     strict = True if strict is None else strict
@@ -45,7 +45,7 @@ def _msgspec_validate_instance(model, body, allow_coerce, strict=True):
         raise TypeError(str(e))
 
 
-def _validate_instance(model, body, allow_coerce, strict=False):
+def _validate_instance(model, body, allow_coerce, strict=None):
     strict = False if strict is None else strict
     data = clean_data(model, body) if allow_coerce else body
     if hasattr(model, "model_validate"):

--- a/sanic_ext/extras/validation/validators.py
+++ b/sanic_ext/extras/validation/validators.py
@@ -34,6 +34,8 @@ def validate_body(
 def _msgspec_validate_instance(model, body, allow_coerce, strict=True):
     import msgspec
 
+    strict = True if strict is None else strict
+
     try:
         data = clean_data(model, body) if allow_coerce else body
         return msgspec.convert(data, model, strict=strict)
@@ -43,10 +45,11 @@ def _msgspec_validate_instance(model, body, allow_coerce, strict=True):
         raise TypeError(str(e))
 
 
-def _validate_instance(model, body, allow_coerce):
+def _validate_instance(model, body, allow_coerce, strict=False):
+    strict = False if strict is None else strict
     data = clean_data(model, body) if allow_coerce else body
     if hasattr(model, "model_validate"):
-        return model.model_validate(data)
+        return model.model_validate(data, strict=strict)
     return model(**data)
 
 

--- a/tests/extra/test_validation_msgspec.py
+++ b/tests/extra/test_validation_msgspec.py
@@ -394,8 +394,8 @@ def test_validate_query(app):
     assert response.json["q"] == "Snoopy"
 
 
-def test_validate_query_mode_coerces_string_to_int(app):
-    """Test that query mode coerces string to int."""
+def test_validate_query_coerces_string_to_int(app):
+    """Test that query coerces string to int."""
 
     class SearchQuery(Struct):
         q: str
@@ -421,7 +421,7 @@ def test_validate_query_mode_coerces_string_to_int(app):
     assert response.json["limit_type"] == "int"
 
 
-def test_validate_query_mode_with_invalid_value(app):
+def test_validate_query_with_invalid_value(app):
     """Test that lax mode still rejects completely invalid values."""
 
     class SearchQuery(Struct):


### PR DESCRIPTION
Since query parameters and forms are always strings, it makes sense that the user would want to coerce them to the appropriate type when validating. Changes strict mode to only apply to json body data.

Also enabled the strict mode to apply to pydantic, though I have the default as lax mode there to mirror pydantic's default behavior on its own. Not sure if that's the right move or overcomplicates things and sanic should have its own consistent default regardless of validator. EDIT: I guess having separate defaults for pydantic vs msgspec is important for backwards compatibility reasons, don't want to suddenly switch on strict mode for pydantic users. If we want to just have one default I suppose it needs to be lax mode for that reason.